### PR TITLE
feat(ctx-verify): add green CI, broken contract pattern

### DIFF
--- a/plugins/ctx/.claude-plugin/plugin.json
+++ b/plugins/ctx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctx",
   "description": "Personal development toolkit built on context economy — brainstorm, plan, execute, ship, QA. Every skill optimizes for minimal token spend with maximum signal.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Garo Nazarian"
   }

--- a/plugins/ctx/hooks/hooks.json
+++ b/plugins/ctx/hooks/hooks.json
@@ -32,6 +32,15 @@
             "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/log-skill-invocation.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/orchestration-verify-nudge.sh\""
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/plugins/ctx/hooks/scripts/orchestration-verify-nudge.sh
+++ b/plugins/ctx/hooks/scripts/orchestration-verify-nudge.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# PostToolUse hook: nudge when test commands complete but service orchestration
+# files are in the diff — reminder to verify path-level side effects, not just
+# function-level test results.
+#
+# Pattern: "Green CI, broken contract" — tests pass ≠ orchestration verified.
+
+INPUT=$(cat)
+command -v jq &>/dev/null || exit 0
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+[ "$TOOL_NAME" != "Bash" ] && exit 0
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$COMMAND" ] && exit 0
+
+# Only fire when the command looks like a test run
+echo "$COMMAND" | grep -qiE '(vitest|jest|npm\s+(run\s+)?test|npx\s+vitest|npx\s+jest)' || exit 0
+
+# Check if service/provider files are in the current branch's diff
+DIFF_FILES=$(git diff --name-only main...HEAD 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null)
+[ -z "$DIFF_FILES" ] && exit 0
+
+echo "$DIFF_FILES" | grep -qiE '(Service|Provider)\.ts$' || exit 0
+
+echo "🔍 Green CI, broken contract?"
+echo ""
+echo "Tests ran, but the diff touches service orchestration files."
+echo "Did the tests verify each code path's side effects — or just the downstream functions?"
+exit 0

--- a/plugins/ctx/skills/ctx-verify/SKILL.md
+++ b/plugins/ctx/skills/ctx-verify/SKILL.md
@@ -61,6 +61,7 @@ Before claiming any status or expressing satisfaction:
 | Regression test works | Red-green cycle verified | Test passes once |
 | Agent completed | VCS diff shows actual changes | Agent reports "success" |
 | Requirements met | Line-by-line checklist against spec | "Tests passing" |
+| Orchestration correct | Path-level: trace data written per code path, assert full side-effect contract | Tests pass, tsc clean (function-level only) |
 
 ---
 
@@ -161,3 +162,4 @@ Any workflow    → Invoke before claiming DONE
 - **Partial verification is not verification.** Running unit tests does not verify the build. Running lint does not verify tests. Each claim needs its own evidence.
 - **Subagents lie (unintentionally).** An agent reporting "DONE" means it thinks it's done. Check the diff yourself.
 - **Time pressure is when this matters most.** The urge to skip verification correlates with the likelihood of bugs. Resist.
+- **Green CI, broken contract.** When changes reorder control flow, add early exits, or reroute side effects, "tests pass + tsc clean" verifies function shape, not orchestration. Trace data written by each code path and assert the full contract (activities created, IDs consistent, associations linked). Signal: diff touches service-layer method ordering or adds `return` before existing logic.


### PR DESCRIPTION
## Summary

- **Skill adjustment**: New "Orchestration correct" verification tier in ctx-verify — requires path-level tracing of data written per code path, not just tests+tsc
- **Gotcha**: "Green CI, broken contract" pattern — when changes reorder control flow or add early exits, tests+tsc verify function shape, not orchestration
- **Hook**: PostToolUse nudge on Bash — fires when test commands run and service/provider files are in the diff

## Why

Discovered during architectural review of a production PR: tests passed and tsc was clean, but the service-layer changes (reordered control flow, early exits, mismatched activity IDs) had zero path-level coverage. The tests verified downstream functions, not the orchestration that changed.

## Version

Bumps ctx-plugin to v0.2.2.

## Test plan

- [ ] Run tests in a project with *Service.ts files in the diff — hook should nudge
- [ ] Run tests in a project without service files in the diff — hook should stay silent
- [ ] Verify ctx-verify skill loads with new table row and gotcha

🤖 Generated with [Claude Code](https://claude.com/claude-code)