### PR TITLE
feat: worktree auto-swap via native EnterWorktree

### DIFF
--- a/docs/context/plans/2026-04-02-worktree-auto-swap.md
+++ b/docs/context/plans/2026-04-02-worktree-auto-swap.md
@@ -1,0 +1,112 @@
+# Worktree Auto-Swap Implementation Plan
+
+**Goal:** Replace the manual "quit and relaunch" worktree handoff with `EnterWorktree` native tool, keeping env symlinks + deps as a post-swap step.
+**Architecture:** Thin skill wrapper calls `EnterWorktree` for session swap, then runs `worktree-post-setup.sh` for env symlinks and dependency install. Verbose stderr logging throughout.
+**Tech Stack:** Bash, Claude Code native tools (`EnterWorktree`/`ExitWorktree`)
+**Total tasks:** 2 ([1 LOW] [1 MED])
+**Estimated agent budget:** 3 (1×1 for LOW, 1×2 for MED)
+
+---
+
+### Task 1: Extract env+deps into `worktree-post-setup.sh` `[LOW]`
+
+**Files:**
+- Create: `plugins/ctx/scripts/worktree-post-setup.sh`
+- Modify: `plugins/ctx/scripts/test-scripts.sh` (add test section)
+
+**Steps:**
+- [ ] Create `worktree-post-setup.sh` extracted from `worktree-create.sh` lines 69-134
+  - Accepts args: `--source <main-repo-root>` `--target <worktree-path>` `[--skip-deps]`
+  - Exit codes: 0 = success, 1 = bad args, 3 = deps failed (worktree still usable)
+  - **Logging:** every decision logged to stderr with `[post-setup]` prefix:
+    - `[post-setup] source=/path/to/repo target=/path/to/worktree`
+    - `[post-setup] checking root .env files...`
+    - `[post-setup] found .env.local — gitignored=yes, symlink=no → symlinking`
+    - `[post-setup] found .env.example — gitignored=no → skipping (tracked)`
+    - `[post-setup] found .env.local — already exists in target → skipping`
+    - `[post-setup] checking monorepo symlinks...`
+    - `[post-setup] found packages/api/.env → symlink to ../../.env.local → recreating`
+    - `[post-setup] checking nested env files...`
+    - `[post-setup] found src/app/.env — gitignored=yes → symlinking`
+    - `[post-setup] symlinked 3 env file(s)`
+    - `[post-setup] detecting package manager...`
+    - `[post-setup] found pnpm-lock.yaml → running pnpm install`
+    - `[post-setup] deps: ok` / `[post-setup] deps: failed (exit code 1)` / `[post-setup] deps: none (no lockfile)`
+  - Structured stdout output (same as worktree-create.sh pattern):
+    ```
+    env_count=3
+    deps=ok
+    ```
+- [ ] `chmod +x worktree-post-setup.sh`
+- [ ] Add test section to `test-scripts.sh`:
+  - Create test repo with `.env.local` (gitignored), `.env.example` (tracked), nested `src/.env` (gitignored)
+  - Run `worktree-post-setup.sh --source <repo> --target <worktree> --skip-deps`
+  - Assert: `env_count=2` (gitignored files only), symlinks exist, tracked file not symlinked
+  - Run with missing `--source` → assert exit 1
+- [ ] Run: `bash plugins/ctx/scripts/test-scripts.sh` — expect all tests PASS
+- [ ] Commit: `feat: add worktree-post-setup.sh for env symlinks and deps`
+
+**Context:** This is a pure extraction from `worktree-create.sh` with added verbose logging. The logging is the main new value — the current script is silent about *why* it skips files, making debugging impossible.
+
+---
+
+### Task 2: Rewrite `ctx-worktree/SKILL.md` to use `EnterWorktree` + post-setup `[MED]`
+
+**Files:**
+- Modify: `plugins/ctx/skills/ctx-worktree/SKILL.md`
+
+**Steps:**
+- [ ] Rewrite SKILL.md with the following sections:
+
+**Section 1: Gather inputs**
+- Only `name` is required (short identifier like `fix-email-bug`)
+- No base branch, no prefix, no skip-deps — `EnterWorktree` handles worktree/branch creation
+- If user didn't provide a name, ask for one
+
+**Section 2: Capture source root**
+- Before calling `EnterWorktree`, capture the current repo root: `git rev-parse --show-toplevel`
+- Store this — it's needed for the post-setup script's `--source` arg
+- Log: the skill should note this in its output so the user sees it
+
+**Section 3: Call EnterWorktree**
+- `EnterWorktree(name: "<name>")`
+- Session CWD swaps to the new worktree
+- If the tool errors (already in a worktree, not a git repo), report and stop
+
+**Section 4: Post-setup**
+- Run: `bash <base-directory>/../../scripts/worktree-post-setup.sh --source <source-root> --target $(pwd)`
+- Parse stdout for `env_count` and `deps` values
+- If exit 3 (deps failed), note worktree is still usable
+
+**Section 5: Present result**
+```
+Worktree ready:
+  Path:   <pwd>
+  Branch: <git branch --show-current>
+  .env:   <env_count> file(s) symlinked
+  Deps:   <deps status>
+
+You're now working in the worktree. Use ExitWorktree when done.
+```
+
+**Section 6: Cleanup reference** (keep unchanged from current)
+- `ExitWorktree(action: "keep")` or `ExitWorktree(action: "remove")`
+- `git worktree list` to see all active worktrees
+
+**Section 7: Gotchas**
+- Update: remove "claude --continue doesn't work across directories" (no longer relevant — session stays live)
+- Add: "If you need a specific base branch, `git rebase <base>` after entering the worktree"
+- Add: "EnterWorktree branches from HEAD — ensure you're on the right branch before invoking"
+
+- [ ] Verify the skill's `allowed-tools` frontmatter includes `EnterWorktree` and `ExitWorktree`
+- [ ] Read the rewritten SKILL.md end-to-end — verify flow is coherent and no references to old `worktree-create.sh` flow remain (except cleanup docs mentioning it still exists for manual use)
+- [ ] Commit: `feat: ctx-worktree uses EnterWorktree for native session swap`
+
+**Context:** This is the core behavior change. The skill goes from "create worktree + tell user to quit" to "swap session into worktree + run post-setup." The `EnterWorktree` tool does the heavy lifting; the skill adds env/deps and user-facing presentation.
+
+---
+
+## Open questions (resolve during Task 2)
+
+1. **`allowed-tools` in frontmatter** — does `EnterWorktree` need to be listed in the skill's `allowed-tools`? If the skill can only use tools listed there, we need to add it. If unlisted tools are still callable, skip it.
+2. **Source root after swap** — after `EnterWorktree` swaps CWD, can we still reference the original repo root from the captured variable, or does the session state reset? Task 2 step 2 captures it pre-swap as a safeguard.

--- a/docs/specs/2026-04-02-worktree-auto-swap-design.md
+++ b/docs/specs/2026-04-02-worktree-auto-swap-design.md
@@ -1,0 +1,101 @@
+# Worktree Auto-Swap
+
+**Date:** 2026-04-02
+**Status:** Draft
+**Complexity:** [LOW] post-setup script, [MED] skill rewrite
+
+## Problem
+
+After `/ctx-worktree` creates an isolated worktree, it prints "quit and relaunch
+in the worktree" — forcing a manual session break. This is the #1 friction point
+in the ctx workflow. Ironic for a tool that automates developer workflows.
+
+## Decision
+
+Replace the manual handoff with `EnterWorktree` — a native Claude Code tool that
+swaps the session into a worktree with zero token overhead. Keep the skill as a
+thin wrapper that adds env symlinks and dependency install after the swap.
+
+**Why not the osascript/terminal approach (original plan)?** `EnterWorktree` was
+discovered after the original plan was written. It handles session swap natively
+inside Claude Code — no terminal detection, no osascript, no `{"continue": false}`
+JSON protocol. The entire `worktree-swap.sh` script is unnecessary.
+
+**Why keep the skill wrapper?** `EnterWorktree` doesn't handle env symlinks or
+dependency install. The skill adds that post-swap, plus provides cleanup docs.
+
+## Design
+
+### Flow
+
+```
+User: "/ctx-worktree" or "create a worktree"
+  → Skill gathers name (only required input now)
+  → Calls EnterWorktree(name: "<name>")
+  → Session swaps into .claude/worktrees/<name>
+  → Skill runs worktree-post-setup.sh (env symlinks + deps)
+  → Ready to work
+```
+
+### Script: worktree-post-setup.sh
+
+Extracted from the env-symlink and deps-install sections of `worktree-create.sh`.
+Accepts `--source <main-repo-root>` and `--target <worktree-path>`.
+
+Handles:
+- Root-level gitignored `.env*` files → symlink to worktree
+- Monorepo symlinks that point to root env files → recreate in worktree
+- Nested gitignored `.env*` files in subdirectories → symlink to worktree
+- Dependency install (pnpm/yarn/npm/pipenv/pip) based on lockfile detection
+
+Does NOT handle (EnterWorktree does these):
+- Worktree creation
+- Branch creation
+- Session CWD swap
+
+### SKILL.md changes
+
+Replace the current 5-section flow with:
+
+1. **Gather inputs** — only `name` is required now (no base branch, no prefix, no skip-deps)
+2. **Call EnterWorktree** — `EnterWorktree(name: "<name>")`
+3. **Post-setup** — run `worktree-post-setup.sh --source <original-root> --target <worktree-path>`
+4. **Present result** — show path, branch, env count, deps status
+5. **Cleanup reference** — unchanged
+
+### What we intentionally drop
+
+- Custom parent directory (`$PARENT_DIR/$PROJECT_NAME-$NAME`) → `.claude/worktrees/` is fine
+- Branch prefix control (`feat/`, `fix/`) → `EnterWorktree` names branches itself
+- Base branch selection → `EnterWorktree` branches from HEAD; `git rebase` if needed
+- `worktree-create.sh` is NOT deleted — it still works for manual use outside Claude
+
+### Data flow
+
+```
+EnterWorktree(name)
+  → creates .claude/worktrees/<name>/ (git worktree)
+  → creates branch, switches session CWD
+  → clears CWD-dependent caches
+
+worktree-post-setup.sh --source /original/repo --target /new/worktree
+  → finds .env* in source (gitignored only)
+  → symlinks to target
+  → detects lockfile in target
+  → runs package manager install
+  → prints key=value summary to stdout
+```
+
+## Success Criteria
+
+- [ ] `/ctx-worktree` swaps session into worktree without user quitting
+- [ ] Env files symlinked in new worktree
+- [ ] Deps installed when lockfile present
+- [ ] `ctx-execute` worktree guard (`[ -f .git ]`) still passes
+- [ ] `ExitWorktree(action: "keep")` returns to original directory
+- [ ] `worktree-create.sh` still works independently (no regression)
+
+## Complexity Tags
+
+- [LOW] Extract env+deps logic into `worktree-post-setup.sh`
+- [MED] Rewrite `ctx-worktree/SKILL.md` to use `EnterWorktree` + post-setup flow

--- a/plugins/ctx/scripts/test-scripts.sh
+++ b/plugins/ctx/scripts/test-scripts.sh
@@ -242,6 +242,90 @@ assert_contains "requires --message" "$OUTPUT" "--message is required"
 
 # ══════════════════════════════════════════════════════════
 echo ""
+echo "=== TEST: worktree-post-setup.sh ==="
+
+# Setup: fresh repo for isolated post-setup testing
+POST_SETUP_SRC="$TEMP_DIR/post-setup-src-bare"
+mkdir -p "$POST_SETUP_SRC"
+git -C "$POST_SETUP_SRC" init --bare -q
+POST_SETUP_REPO="$TEMP_DIR/post-setup-src"
+git clone -q "$POST_SETUP_SRC" "$POST_SETUP_REPO"
+cd "$POST_SETUP_REPO"
+git config user.email "test@test.com"
+git config user.name "Test"
+
+# Initial commit + gitignore rules
+echo "hello" > file.txt
+printf ".env.local\nsrc/app/.env\n" > .gitignore
+git add file.txt .gitignore
+git commit -q -m "init with gitignore"
+
+# Tracked env file (should NOT be symlinked)
+echo "PUBLIC=xyz" > .env.example
+git add .env.example
+git commit -q -m "add tracked env example"
+git push -q origin main
+
+# Create gitignored env files on disk (not tracked)
+echo "SECRET=abc" > .env.local
+mkdir -p src/app
+echo "NESTED_SECRET=123" > src/app/.env
+
+# Create a plain worktree (simulates EnterWorktree — no worktree-create.sh)
+git worktree add -b post-setup-test "$TEMP_DIR/post-setup-target" origin/main 2>/dev/null
+POST_SETUP_TARGET="$TEMP_DIR/post-setup-target"
+
+# Happy path: symlink env files, skip deps
+OUTPUT=$(bash "$SCRIPT_DIR/worktree-post-setup.sh" --source "$POST_SETUP_REPO" --target "$POST_SETUP_TARGET" --skip-deps 2>/dev/null)
+assert_contains "env_count=2" "$OUTPUT" "env_count=2"
+assert_contains "deps=skipped" "$OUTPUT" "deps=skipped"
+
+# Verify symlinks exist
+if [[ -L "$POST_SETUP_TARGET/.env.local" ]]; then
+  echo "  PASS: .env.local symlinked"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: .env.local not symlinked"
+  FAIL=$((FAIL + 1))
+fi
+
+if [[ -L "$POST_SETUP_TARGET/src/app/.env" ]]; then
+  echo "  PASS: src/app/.env symlinked"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: src/app/.env not symlinked"
+  FAIL=$((FAIL + 1))
+fi
+
+# .env.example is tracked — should NOT be symlinked (it's already in the worktree via git)
+if [[ ! -L "$POST_SETUP_TARGET/.env.example" ]]; then
+  echo "  PASS: .env.example not symlinked (tracked)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: .env.example was symlinked (should be tracked)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Missing --source
+OUTPUT=$(bash "$SCRIPT_DIR/worktree-post-setup.sh" --target /tmp 2>&1 || true)
+assert_contains "requires --source" "$OUTPUT" "--source is required"
+
+# Missing --target
+OUTPUT=$(bash "$SCRIPT_DIR/worktree-post-setup.sh" --source /tmp 2>&1 || true)
+assert_contains "requires --target" "$OUTPUT" "--target is required"
+
+# Verbose logging check (stderr should contain [post-setup] lines)
+STDERR_OUTPUT=$(bash "$SCRIPT_DIR/worktree-post-setup.sh" --source "$POST_SETUP_REPO" --target "$POST_SETUP_TARGET" --skip-deps 2>&1 >/dev/null)
+if echo "$STDERR_OUTPUT" | grep -q "\[post-setup\]"; then
+  echo "  PASS: stderr contains [post-setup] logging"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: no [post-setup] logging in stderr"
+  FAIL=$((FAIL + 1))
+fi
+
+# ══════════════════════════════════════════════════════════
+echo ""
 echo "════════════════════════════════"
 echo "Results: $PASS passed, $FAIL failed"
 echo "════════════════════════════════"

--- a/plugins/ctx/scripts/worktree-post-setup.sh
+++ b/plugins/ctx/scripts/worktree-post-setup.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# worktree-post-setup.sh — Symlink env files and install deps in an existing worktree.
+# Extracted from worktree-create.sh. Designed to run AFTER EnterWorktree creates the worktree.
+#
+# Usage:
+#   worktree-post-setup.sh --source <main-repo-root> --target <worktree-path> [--skip-deps]
+#
+# Exit codes:
+#   0 — success
+#   1 — bad arguments
+#   3 — dependency install failed (worktree still usable)
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────
+SOURCE=""
+TARGET=""
+SKIP_DEPS=false
+
+log() { echo "[post-setup] $*" >&2; }
+
+# ── Parse args ────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source)    SOURCE="$2"; shift 2 ;;
+    --target)    TARGET="$2"; shift 2 ;;
+    --skip-deps) SKIP_DEPS=true; shift ;;
+    -h|--help)
+      echo "Usage: worktree-post-setup.sh --source <main-repo-root> --target <worktree-path> [--skip-deps]"
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -z "$SOURCE" ]] && { echo "Error: --source is required" >&2; exit 1; }
+[[ -z "$TARGET" ]] && { echo "Error: --target is required" >&2; exit 1; }
+[[ -d "$SOURCE" ]] || { echo "Error: source directory does not exist: $SOURCE" >&2; exit 1; }
+[[ -d "$TARGET" ]] || { echo "Error: target directory does not exist: $TARGET" >&2; exit 1; }
+
+log "source=$SOURCE target=$TARGET skip_deps=$SKIP_DEPS"
+
+# ── Symlink env files ─────────────────────────────────────
+ENV_COUNT=0
+
+# Root-level env files (only gitignored real files — templates/examples are tracked)
+log "checking root .env files..."
+for f in "$SOURCE"/.env*; do
+  BASENAME=$(basename "$f")
+  if [[ ! -f "$f" || -L "$f" ]]; then
+    log "found $BASENAME — not a regular file → skipping"
+    continue
+  fi
+  if ! git -C "$SOURCE" check-ignore -q "$f" 2>/dev/null; then
+    log "found $BASENAME — gitignored=no → skipping (tracked)"
+    continue
+  fi
+  DEST="$TARGET/$BASENAME"
+  if [[ -e "$DEST" ]]; then
+    log "found $BASENAME — gitignored=yes, already exists in target → skipping"
+    continue
+  fi
+  ln -s "$f" "$DEST" && ENV_COUNT=$((ENV_COUNT + 1))
+  log "found $BASENAME — gitignored=yes → symlinked"
+done
+
+# Monorepo: recreate symlinks that point to root env files
+log "checking monorepo symlinks..."
+MONO_FOUND=0
+while IFS= read -r link; do
+  [[ -z "$link" ]] && continue
+  MONO_FOUND=$((MONO_FOUND + 1))
+  REL_PATH="${link#$SOURCE/}"
+  LINK_TARGET=$(readlink "$link")
+  DEST="$TARGET/$REL_PATH"
+  DEST_DIR=$(dirname "$DEST")
+  if [[ ! -d "$DEST_DIR" ]]; then
+    log "found $REL_PATH → $LINK_TARGET — creating dest dir $DEST_DIR"
+    mkdir -p "$DEST_DIR"
+  fi
+  if [[ -e "$DEST" ]]; then
+    log "found $REL_PATH → $LINK_TARGET — already exists → skipping"
+    continue
+  fi
+  ln -s "$LINK_TARGET" "$DEST" && ENV_COUNT=$((ENV_COUNT + 1))
+  log "found $REL_PATH → $LINK_TARGET → recreated"
+done < <(find "$SOURCE" -name ".env*" -type l 2>/dev/null)
+[[ $MONO_FOUND -eq 0 ]] && log "no monorepo symlinks found"
+
+# Nested gitignored env files (e.g. src/app/.env) — real files in subdirectories
+log "checking nested env files..."
+NESTED_FOUND=0
+while IFS= read -r envfile; do
+  [[ -z "$envfile" ]] && continue
+  # Skip root-level (already handled above) and symlinks
+  [[ "$envfile" == "$SOURCE"/.env* ]] && continue
+  [[ -L "$envfile" ]] && continue
+  NESTED_FOUND=$((NESTED_FOUND + 1))
+  REL_PATH="${envfile#$SOURCE/}"
+  if ! git -C "$SOURCE" check-ignore -q "$envfile" 2>/dev/null; then
+    log "found $REL_PATH — gitignored=no → skipping (tracked)"
+    continue
+  fi
+  DEST="$TARGET/$REL_PATH"
+  DEST_DIR=$(dirname "$DEST")
+  if [[ ! -d "$DEST_DIR" ]]; then
+    log "found $REL_PATH — gitignored=yes, creating dest dir $DEST_DIR"
+    mkdir -p "$DEST_DIR"
+  fi
+  if [[ -e "$DEST" ]]; then
+    log "found $REL_PATH — gitignored=yes, already exists → skipping"
+    continue
+  fi
+  ln -s "$envfile" "$DEST" && ENV_COUNT=$((ENV_COUNT + 1))
+  log "found $REL_PATH — gitignored=yes → symlinked"
+done < <(find "$SOURCE" -name ".env*" -type f 2>/dev/null)
+[[ $NESTED_FOUND -eq 0 ]] && log "no nested env files found"
+
+log "symlinked $ENV_COUNT env file(s) total"
+
+# ── Install dependencies ──────────────────────────────────
+DEPS_STATUS="skipped"
+if [[ "$SKIP_DEPS" == false ]]; then
+  log "detecting package manager..."
+  if [[ -f "$TARGET/pnpm-lock.yaml" ]]; then
+    log "found pnpm-lock.yaml → running pnpm install"
+    (cd "$TARGET" && pnpm install 2>&1 >&2) && DEPS_STATUS="ok" || DEPS_STATUS="failed"
+  elif [[ -f "$TARGET/yarn.lock" ]]; then
+    log "found yarn.lock → running yarn install"
+    (cd "$TARGET" && yarn install 2>&1 >&2) && DEPS_STATUS="ok" || DEPS_STATUS="failed"
+  elif [[ -f "$TARGET/package-lock.json" ]]; then
+    log "found package-lock.json → running npm install"
+    (cd "$TARGET" && npm install 2>&1 >&2) && DEPS_STATUS="ok" || DEPS_STATUS="failed"
+  elif [[ -f "$TARGET/Pipfile.lock" ]]; then
+    log "found Pipfile.lock → running pipenv install"
+    (cd "$TARGET" && pipenv install 2>&1 >&2) && DEPS_STATUS="ok" || DEPS_STATUS="failed"
+  elif [[ -f "$TARGET/requirements.txt" ]]; then
+    log "found requirements.txt → running pip install"
+    (cd "$TARGET" && pip install -r requirements.txt 2>&1 >&2) && DEPS_STATUS="ok" || DEPS_STATUS="failed"
+  else
+    DEPS_STATUS="none"
+    log "no lockfile found → skipping deps"
+  fi
+
+  if [[ "$DEPS_STATUS" == "failed" ]]; then
+    log "deps: failed — worktree still usable, install manually"
+  elif [[ "$DEPS_STATUS" == "ok" ]]; then
+    log "deps: ok"
+  fi
+else
+  log "deps: skipped (--skip-deps)"
+fi
+
+# ── Structured output (stdout) ────────────────────────────
+cat <<EOF
+env_count=$ENV_COUNT
+deps=$DEPS_STATUS
+EOF
+
+[[ "$DEPS_STATUS" == "failed" ]] && exit 3
+exit 0

--- a/plugins/ctx/skills/ctx-execute/SKILL.md
+++ b/plugins/ctx/skills/ctx-execute/SKILL.md
@@ -45,7 +45,7 @@ Before doing anything else, check if we're running inside a git worktree:
 
 **If `main checkout`:** STOP. Do not read the plan, do not dispatch agents. Tell the user:
 
-> "You're on the main checkout. `/ctx-execute` requires an isolated worktree so implementation doesn't touch your main working directory. Run `/ctx-worktree` first, then relaunch Claude from the worktree and re-invoke `/ctx-execute`."
+> "You're on the main checkout. `/ctx-execute` requires an isolated worktree so implementation doesn't touch your main working directory. Run `/ctx-worktree` first — it will swap you into the worktree automatically — then re-invoke `/ctx-execute`."
 
 **Why this is a hard gate:** Subagents write code and commit. If they do that on the main checkout, a failed or partial implementation leaves debris on `main` that's harder to clean up than deleting a worktree branch. The worktree is the undo button.
 

--- a/plugins/ctx/skills/ctx-worktree/SKILL.md
+++ b/plugins/ctx/skills/ctx-worktree/SKILL.md
@@ -4,13 +4,13 @@ description: >
   Use when the user wants to work on something in parallel — creates an isolated git
   worktree with env symlinks and dependency install so it's immediately runnable.
   Triggers: "worktree", "new worktree", "isolated branch", "parallel branch".
-allowed-tools: Bash, Read, Glob, EnterWorktree, ExitWorktree
+allowed-tools: Bash, Read, Glob, Write, EnterWorktree, ExitWorktree
 user-invocable: true
 ---
 
 # /worktree — Create an Isolated Git Worktree
 
-Uses Claude Code's native `EnterWorktree` tool for session swap, then runs `worktree-post-setup.sh` for env symlinks and dependency install.
+Uses Claude Code's native `EnterWorktree` tool for session swap, then runs `worktree-post-setup.sh` for env symlinks and dependency install. Parks conversation context into the new worktree so `/ctx-grab` can restore it.
 
 ## 1. Gather inputs
 
@@ -20,15 +20,25 @@ Ask the user if not already provided:
 
 That's it. `EnterWorktree` handles branch creation and worktree setup internally.
 
-## 2. Capture source root
+## 2. Capture source root and park context
 
-Before swapping, capture the current repo root — it's needed for the post-setup script:
+Before swapping, two things must happen:
+
+**a) Capture source root** — needed for the post-setup script:
 
 ```bash
 SOURCE_ROOT=$(git rev-parse --show-toplevel)
 ```
 
-Store this value. After `EnterWorktree` swaps the session, the original repo root is no longer the CWD.
+**b) Distill conversation context** — from the current conversation, extract:
+
+- What the user is trying to accomplish (the task/goal)
+- Key decisions made and their rationale
+- Approaches tried or ruled out
+- Relevant file paths, specs, or plans discussed
+- What should happen next in the worktree
+
+Store this as a string — it will be written to the worktree after the swap.
 
 ## 3. Call EnterWorktree
 
@@ -44,7 +54,35 @@ This:
 
 If the tool errors (already in a worktree, not a git repo), report the error and stop.
 
-## 4. Post-setup
+## 4. Write handoff into worktree
+
+Write the distilled context to `.claude/ctx-park.md` in the new worktree so `/ctx-grab` can find it:
+
+```bash
+mkdir -p .claude
+```
+
+Then use the Write tool to create `.claude/ctx-park.md`:
+
+```markdown
+# Context Park — {worktree-name}
+
+**Parked:** {timestamp}
+**Branch:** {branch from git branch --show-current}
+**Session:** {One sentence — what this session is for}
+
+## Smart Context
+
+{Numbered list from step 2b — decisions, rationale, key files}
+
+## Next Steps
+
+{What to do first in this worktree}
+```
+
+This means if the session ends or context gets large, `/ctx-grab` can restore it.
+
+## 5. Post-setup
 
 Run the post-setup script to symlink env files and install dependencies:
 
@@ -59,7 +97,7 @@ Parse the stdout values (`env_count`, `deps`). The script logs detailed progress
 
 If the script exits with code 3 (deps failed), note the worktree is still usable — deps can be installed manually.
 
-## 5. Present result
+## 6. Present result
 
 ```
 Worktree ready:
@@ -67,11 +105,12 @@ Worktree ready:
   Branch: <git branch --show-current>
   .env:   <env_count> file(s) symlinked
   Deps:   <deps status>
+  Context: parked to .claude/ctx-park.md
 
 You're now working in the worktree. Use ExitWorktree when done.
 ```
 
-## 6. Cleanup reference
+## 7. Cleanup reference
 
 When the user asks about leaving or removing worktrees:
 
@@ -86,3 +125,4 @@ The old `worktree-create.sh` script still exists for manual worktree creation ou
 - `EnterWorktree` branches from HEAD. If the user needs a specific base branch, they should checkout that branch first or `git rebase <base>` after entering the worktree.
 - On session exit while still in a worktree, Claude Code prompts the user to keep or remove it.
 - The post-setup script creates missing directories for nested env files (e.g., `src/app/` may not exist in the worktree if its only content was gitignored).
+- The handoff written in step 4 is a snapshot of conversation context at worktree creation time. If the session continues with significant new context, `/ctx-park` should be run again before ending the session.

--- a/plugins/ctx/skills/ctx-worktree/SKILL.md
+++ b/plugins/ctx/skills/ctx-worktree/SKILL.md
@@ -4,65 +4,85 @@ description: >
   Use when the user wants to work on something in parallel — creates an isolated git
   worktree with env symlinks and dependency install so it's immediately runnable.
   Triggers: "worktree", "new worktree", "isolated branch", "parallel branch".
-allowed-tools: Bash, Read, Glob
+allowed-tools: Bash, Read, Glob, EnterWorktree, ExitWorktree
 user-invocable: true
 ---
 
 # /worktree — Create an Isolated Git Worktree
 
-Delegates mechanical work to `scripts/worktree-create.sh`. This skill handles judgment only.
+Uses Claude Code's native `EnterWorktree` tool for session swap, then runs `worktree-post-setup.sh` for env symlinks and dependency install.
 
 ## 1. Gather inputs
 
 Ask the user if not already provided:
 
 - **Name**: short identifier (e.g., `fix-email-bug`, `new-search-ui`)
-- **Base branch**: default `main`
-- **Branch prefix**: `feat/`, `fix/`, `hotfix/`, or `--no-prefix`. Default: `feat/`
-- **Skip deps?** If they say they won't need a dev server, add `--skip-deps`
 
-## 2. Run the script
+That's it. `EnterWorktree` handles branch creation and worktree setup internally.
 
-The script is at `../../scripts/worktree-create.sh` relative to this skill's base directory (shown in the skill loading message). Resolve the full path and run:
+## 2. Capture source root
+
+Before swapping, capture the current repo root — it's needed for the post-setup script:
 
 ```bash
-bash <base-directory>/../../scripts/worktree-create.sh \
-  --name <name> --base <base> --prefix <prefix>
+SOURCE_ROOT=$(git rev-parse --show-toplevel)
 ```
 
-The script prints progress to stderr and a `key=value` summary to stdout. Parse the stdout values.
+Store this value. After `EnterWorktree` swaps the session, the original repo root is no longer the CWD.
 
-## 3. Interpret result and present
+## 3. Call EnterWorktree
 
-On **success** (exit 0), present:
+```
+EnterWorktree(name: "<name>")
+```
+
+This:
+- Creates a worktree under `.claude/worktrees/<name>/`
+- Creates a new branch based on HEAD
+- Switches the session's working directory to the worktree
+- Clears CWD-dependent caches
+
+If the tool errors (already in a worktree, not a git repo), report the error and stop.
+
+## 4. Post-setup
+
+Run the post-setup script to symlink env files and install dependencies:
+
+```bash
+bash <base-directory>/../../scripts/worktree-post-setup.sh \
+  --source "$SOURCE_ROOT" --target "$(pwd)"
+```
+
+The script is at `../../scripts/worktree-post-setup.sh` relative to this skill's base directory (shown in the skill loading message). Resolve the full path before running.
+
+Parse the stdout values (`env_count`, `deps`). The script logs detailed progress to stderr with `[post-setup]` prefix — this is visible in the Bash tool output.
+
+If the script exits with code 3 (deps failed), note the worktree is still usable — deps can be installed manually.
+
+## 5. Present result
 
 ```
 Worktree ready:
-  Path:   <path>
-  Branch: <branch>
-  Base:   <base>
+  Path:   <pwd>
+  Branch: <git branch --show-current>
   .env:   <env_count> file(s) symlinked
   Deps:   <deps status>
 
-To work here, quit and relaunch:
-  cd <path> && claude
+You're now working in the worktree. Use ExitWorktree when done.
 ```
 
-On **failure** (exit 2 = git error, exit 3 = deps failed), report the stderr message and ask the user how to proceed.
+## 6. Cleanup reference
 
-If `deps=failed`, note the worktree still exists and is usable — deps can be installed manually.
+When the user asks about leaving or removing worktrees:
 
-## 4. Cleanup reference
+- **Keep worktree, return to original dir:** `ExitWorktree(action: "keep")`
+- **Remove worktree and branch:** `ExitWorktree(action: "remove")`
+- **List all worktrees:** `git worktree list`
 
-When the user asks about removing worktrees:
+The old `worktree-create.sh` script still exists for manual worktree creation outside Claude.
 
-```bash
-git worktree remove <path>        # clean removal
-git worktree remove --force <path> # if changes were discarded
-git branch -d <branch-name>       # delete branch if no longer needed
-git worktree list                  # see all active worktrees
-```
+## Gotchas
 
-## Gotcha
-
-`claude --continue` doesn't work across directories. Always start a NEW session in the worktree.
+- `EnterWorktree` branches from HEAD. If the user needs a specific base branch, they should checkout that branch first or `git rebase <base>` after entering the worktree.
+- On session exit while still in a worktree, Claude Code prompts the user to keep or remove it.
+- The post-setup script creates missing directories for nested env files (e.g., `src/app/` may not exist in the worktree if its only content was gitignored).


### PR DESCRIPTION
## Summary

- Replaces the manual "quit and relaunch" worktree handoff with Claude Code's native `EnterWorktree` tool, which swaps the session CWD into the worktree without breaking context
- Extracts env-symlink and dependency-install logic into standalone `worktree-post-setup.sh` with verbose `[post-setup]` stderr logging for every decision (symlink, skip, mkdir, deps)
- Updates `ctx-execute` stale reference that told users to "relaunch Claude from the worktree"

## Motivation

The old flow created the worktree successfully but couldn't swap the session — Claude would print "quit and relaunch" and the user had to manually `cd` + restart. This caused:

1. **Context loss** — new session has zero conversation history, all brainstorm/plan context gone
2. **Token waste** — cold restart reloads all plugins/hooks (~5K+ tokens), user re-explains intent
3. **Worktree guard deadlock** — if Claude tried to operate on the new worktree from the main checkout, the guard correctly blocked it (see below)

Real failure from production:
```
⏺ Bash(git worktree add .../project-worktree-137 worktree-137)
  ⎿  ✓ worktree created

⏺ Bash(ln -sf .env.local ...)
  ⎿  BLOCKED — you're editing in the main checkout
     Create an isolated worktree first: /ctx-worktree

⏺ "You'll need to relaunch from the worktree:
    cd .../project-worktree-137 && claude"
```

`EnterWorktree` is the only thing that can swap the session CWD — bash scripts can't do it.

## Changes

| File | What |
|------|------|
| `plugins/ctx/scripts/worktree-post-setup.sh` | New script — env symlinks + deps with verbose logging |
| `plugins/ctx/scripts/test-scripts.sh` | 8 new tests for post-setup (37 total, all pass) |
| `plugins/ctx/skills/ctx-worktree/SKILL.md` | Rewritten to use `EnterWorktree` + post-setup |
| `plugins/ctx/skills/ctx-execute/SKILL.md` | Updated stale "relaunch" message |
| `docs/specs/...` | Design spec |
| `docs/context/plans/...` | Implementation plan |

## Test plan

- [x] `bash plugins/ctx/scripts/test-scripts.sh` — 37/37 pass
- [x] Post-setup correctly symlinks gitignored `.env*` files, skips tracked ones
- [x] Post-setup creates missing dirs for nested env files
- [x] Missing `--source`/`--target` args → exit 1
- [x] Verbose `[post-setup]` stderr logging present
- [ ] Manual: invoke `/ctx-worktree` in a real repo, verify session swaps without quitting
- [ ] Manual: verify `ExitWorktree(action: "keep")` returns to original dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)