### PR TITLE
feat: add ctx-open skill

### DIFF
--- a/plugins/ctx/scripts/open-webstorm.sh
+++ b/plugins/ctx/scripts/open-webstorm.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+open -a "WebStorm" "${1:-$(pwd)}"

--- a/plugins/ctx/skills/ctx-open/SKILL.md
+++ b/plugins/ctx/skills/ctx-open/SKILL.md
@@ -11,4 +11,4 @@ user-invocable: true
 
 Open the current working directory in WebStorm.
 
-Run `~/.claude/scripts/open-web.sh` — no confirmation needed.
+Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/open-webstorm.sh` — no confirmation needed.

--- a/plugins/ctx/skills/ctx-open/SKILL.md
+++ b/plugins/ctx/skills/ctx-open/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: ctx-open
+description: >
+  Open current working directory in WebStorm.
+  Use when the user says "open in WebStorm", "open IDE", "open editor",
+  or invokes /ctx-open.
+user-invocable: true
+---
+
+# /ctx-open
+
+Open the current working directory in WebStorm.
+
+Run `~/.claude/scripts/open-web.sh` — no confirmation needed.


### PR DESCRIPTION
## Summary
- Adds `/ctx-open` skill that opens the current working directory in WebStorm via `~/.claude/scripts/open-web.sh`

## Test plan
- [x] Verified skill appears in autocomplete after deploying to marketplaces directory
- [ ] Invoke `/ctx-open` and confirm WebStorm opens to cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)