### PR TITLE
feat: add ctx-kill-wt skill

### DIFF
--- a/plugins/ctx/scripts/kill-wt.sh
+++ b/plugins/ctx/scripts/kill-wt.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# kill-wt.sh — Teardown a git worktree: kill port, remove worktree, delete branch.
+#
+# Usage:
+#   kill-wt.sh [--port <port>] [--force] [--keep-branch]
+#
+# Must be run from inside the worktree you want to kill.
+# Exit codes: 0=success, 1=bad args, 2=git error
+
+set -euo pipefail
+
+PORT=""
+FORCE=false
+KEEP_BRANCH=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)        PORT="$2"; shift 2 ;;
+    --force)       FORCE=true; shift ;;
+    --keep-branch) KEEP_BRANCH=true; shift ;;
+    -h|--help)
+      echo "Usage: kill-wt.sh [--port <port>] [--force] [--keep-branch]"
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Detect worktree ──────────────────────────────────────
+WORKTREE_PATH=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo" >&2; exit 2; }
+MAIN_REPO=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')
+
+if [[ "$WORKTREE_PATH" == "$MAIN_REPO" ]]; then
+  echo "Error: you are in the main worktree, not a linked worktree" >&2
+  exit 2
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+echo "Worktree: $WORKTREE_PATH" >&2
+echo "Branch:   $BRANCH" >&2
+
+# ── Kill port ────────────────────────────────────────────
+PORT_KILLED="none"
+if [[ -n "$PORT" ]]; then
+  PIDS=$(lsof -ti:"$PORT" 2>/dev/null || true)
+  if [[ -n "$PIDS" ]]; then
+    echo "Killing processes on port $PORT: $PIDS" >&2
+    echo "$PIDS" | xargs kill -9 2>/dev/null || true
+    PORT_KILLED="$PORT"
+  else
+    echo "No process found on port $PORT" >&2
+  fi
+fi
+
+# ── Switch to main repo before removal ───────────────────
+cd "$MAIN_REPO"
+
+# ── Remove worktree ──────────────────────────────────────
+if [[ "$FORCE" == true ]]; then
+  git worktree remove --force "$WORKTREE_PATH" 2>&1 >&2
+else
+  git worktree remove "$WORKTREE_PATH" 2>&1 >&2
+fi
+echo "Worktree removed" >&2
+
+# ── Delete branch if merged ──────────────────────────────
+BRANCH_STATUS="kept"
+if [[ "$KEEP_BRANCH" == false && -n "$BRANCH" && "$BRANCH" != "main" && "$BRANCH" != "master" ]]; then
+  if git branch -d "$BRANCH" 2>/dev/null; then
+    BRANCH_STATUS="deleted"
+    echo "Branch '$BRANCH' deleted (was merged)" >&2
+  else
+    BRANCH_STATUS="kept (not fully merged)"
+    echo "Branch '$BRANCH' not deleted (not fully merged)" >&2
+  fi
+fi
+
+# ── Structured output ───────────────────────────────────
+cat <<EOF
+worktree=$WORKTREE_PATH
+branch=$BRANCH
+branch_status=$BRANCH_STATUS
+port_killed=$PORT_KILLED
+main_repo=$MAIN_REPO
+EOF

--- a/plugins/ctx/skills/ctx-kill-wt/SKILL.md
+++ b/plugins/ctx/skills/ctx-kill-wt/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: ctx-kill-wt
+description: >
+  Teardown a git worktree — kill dev server port, remove worktree, delete branch.
+  Use after merging a PR when you're done with a worktree, or when the user says
+  "kill worktree", "tear down", "clean up worktree", "remove worktree", or /ctx-kill-wt.
+user-invocable: true
+---
+
+# /ctx-kill-wt — Worktree Teardown
+
+Kills the dev server, removes the worktree directory, and cleans up the branch. The inverse of `/ctx-worktree`.
+
+## 1. Gather inputs
+
+You need:
+
+- **Port** (optional): the dev server port to kill. If unknown, check for a running Next.js/Vite/etc process or ask.
+- **Force?**: use `--force` if there are uncommitted changes the user wants to discard.
+- **Keep branch?**: use `--keep-branch` if the branch shouldn't be deleted (e.g., PR still open).
+
+## 2. Run teardown
+
+Must be run from inside the worktree being killed:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/kill-wt.sh --port <port>
+```
+
+The script:
+1. Validates you're in a linked worktree (not main)
+2. Kills processes on the port
+3. `cd`s to the main repo and runs `git worktree remove`
+4. Deletes the branch if it's fully merged (safe `git branch -d`)
+
+Parse the `key=value` stdout output.
+
+## 3. Present result
+
+```
+Worktree killed:
+  Path:     <worktree path>
+  Branch:   <branch> (<deleted|kept>)
+  Port:     <killed|none>
+  Main repo: <path>
+```
+
+After teardown, you're back in the main repo. Let the user know they can `cd` there or that the terminal session should be closed.


### PR DESCRIPTION
## Summary
- Adds `/ctx-kill-wt` skill — worktree teardown that kills dev server port, removes worktree, and deletes the local branch if merged
- Inverse of `/ctx-worktree`
- Bundled `kill-wt.sh` script following the same pattern as `worktree-create.sh`

## Test plan
- [ ] Run `/ctx-kill-wt` from inside a linked worktree
- [ ] Verify port is killed, worktree removed, branch deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)