### PR TITLE
fix: kill-wt safe teardown — --worktree and --detach flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.8.1 (2026-04-05)
+
+- **kill-wt safe teardown** — `--worktree` flag for remote kill from main repo, `--detach` flag for background teardown when session is inside the worktree being killed. Prevents destroying Claude Code session.
+
 ## 0.2.8 (2026-04-05)
 
 - **Companion factory MVP** — portfolio landing page at `/factory`, per-page events persisted to `companion/pages/<page>/.events`, `/factory/<page>` deep-linking, `/api/page-status` endpoint

--- a/plugins/ctx/.claude-plugin/plugin.json
+++ b/plugins/ctx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctx",
   "description": "Personal development toolkit built on context economy — brainstorm, plan, execute, ship, QA. Every skill optimizes for minimal token spend with maximum signal.",
-  "version": "0.2.8",
+  "version": "0.2.8.1",
   "author": {
     "name": "Garo Nazarian"
   }

--- a/plugins/ctx/scripts/kill-wt.sh
+++ b/plugins/ctx/scripts/kill-wt.sh
@@ -2,9 +2,11 @@
 # kill-wt.sh — Teardown a git worktree: kill port, remove worktree, delete branch.
 #
 # Usage:
-#   kill-wt.sh [--port <port>] [--force] [--keep-branch]
+#   kill-wt.sh [--port <port>] [--force] [--keep-branch] [--worktree <path>] [--detach]
 #
-# Must be run from inside the worktree you want to kill.
+# Can be run from inside the worktree OR from outside with --worktree <path>.
+# Use --detach when running from inside the worktree being killed — spawns
+# the teardown in a background shell so the calling session isn't destroyed.
 # Exit codes: 0=success, 1=bad args, 2=git error
 
 set -euo pipefail
@@ -12,32 +14,67 @@ set -euo pipefail
 PORT=""
 FORCE=false
 KEEP_BRANCH=false
+WORKTREE_ARG=""
+DETACH=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --port)        PORT="$2"; shift 2 ;;
     --force)       FORCE=true; shift ;;
     --keep-branch) KEEP_BRANCH=true; shift ;;
+    --worktree)    WORKTREE_ARG="$2"; shift 2 ;;
+    --detach)      DETACH=true; shift ;;
     -h|--help)
-      echo "Usage: kill-wt.sh [--port <port>] [--force] [--keep-branch]"
+      echo "Usage: kill-wt.sh [--port <port>] [--force] [--keep-branch] [--worktree <path>] [--detach]"
       exit 0 ;;
     *) echo "Unknown arg: $1" >&2; exit 1 ;;
   esac
 done
 
 # ── Detect worktree ──────────────────────────────────────
-WORKTREE_PATH=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo" >&2; exit 2; }
-MAIN_REPO=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')
+if [[ -n "$WORKTREE_ARG" ]]; then
+  # Worktree path provided explicitly — resolve and validate
+  WORKTREE_PATH=$(cd "$WORKTREE_ARG" && git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Error: '$WORKTREE_ARG' is not a valid git worktree" >&2; exit 2;
+  }
+  MAIN_REPO=$(cd "$WORKTREE_ARG" && git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')
+  BRANCH=$(cd "$WORKTREE_ARG" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+else
+  # Detect from current directory
+  WORKTREE_PATH=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo" >&2; exit 2; }
+  MAIN_REPO=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+fi
 
 if [[ "$WORKTREE_PATH" == "$MAIN_REPO" ]]; then
-  echo "Error: you are in the main worktree, not a linked worktree" >&2
+  echo "Error: target is the main worktree, not a linked worktree" >&2
   exit 2
 fi
 
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-
 echo "Worktree: $WORKTREE_PATH" >&2
 echo "Branch:   $BRANCH" >&2
+
+# ── Detach mode: re-launch from main repo in background ──
+if [[ "$DETACH" == true ]]; then
+  LOG="/tmp/kill-wt-$(date +%s).log"
+  # Build the args to forward (without --detach, with explicit --worktree)
+  FWD_ARGS=("--worktree" "$WORKTREE_PATH")
+  [[ -n "$PORT" ]]           && FWD_ARGS+=("--port" "$PORT")
+  [[ "$FORCE" == true ]]     && FWD_ARGS+=("--force")
+  [[ "$KEEP_BRANCH" == true ]] && FWD_ARGS+=("--keep-branch")
+
+  SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+  nohup bash -c "cd '$MAIN_REPO' && bash '$SCRIPT_PATH' ${FWD_ARGS[*]}" > "$LOG" 2>&1 &
+  echo "Detached teardown spawned (pid $!, log: $LOG)" >&2
+  cat <<EOF
+detached=true
+log=$LOG
+main_repo=$MAIN_REPO
+worktree=$WORKTREE_PATH
+branch=$BRANCH
+EOF
+  exit 0
+fi
 
 # ── Kill port ────────────────────────────────────────────
 PORT_KILLED="none"

--- a/plugins/ctx/skills/ctx-kill-wt/SKILL.md
+++ b/plugins/ctx/skills/ctx-kill-wt/SKILL.md
@@ -21,14 +21,37 @@ You need:
 
 ## 2. Run teardown
 
-Must be run from inside the worktree being killed:
+**Critical: avoid destroying your own working directory.**
+
+Check: is this session's project root the worktree you're about to kill?
+- Run `pwd` — if it matches the worktree path, you're inside it.
+
+### Case A: Session is in the main repo (or a different worktree)
+
+Safe to kill directly with `--worktree`:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/kill-wt.sh --port <port>
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/kill-wt.sh --worktree <worktree-path> --port <port>
 ```
 
-The script:
-1. Validates you're in a linked worktree (not main)
+### Case B: Session started from inside the worktree being killed
+
+Claude Code's project root IS the worktree — `cd` won't persist, and removing the directory kills the session. Use `--detach` to spawn the teardown in a background process:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/kill-wt.sh --detach --port <port>
+```
+
+This:
+1. Spawns `nohup` teardown from the main repo
+2. Returns immediately with `detached=true` and a log path
+3. Leaves the session alive long enough to show the result
+
+After showing the result, tell the user: **"This session's directory will be removed. Close this tab and open a new session from `<main_repo>`."**
+
+### What the script does
+
+1. Validates the target is a linked worktree (not main — hard block)
 2. Kills processes on the port
 3. `cd`s to the main repo and runs `git worktree remove`
 4. Deletes the branch if it's fully merged (safe `git branch -d`)
@@ -45,4 +68,4 @@ Worktree killed:
   Main repo: <path>
 ```
 
-After teardown, you're back in the main repo. Let the user know they can `cd` there or that the terminal session should be closed.
+If detached, also show the log path and remind the user to close the session.


### PR DESCRIPTION
## Summary

- **`--worktree <path>`** — kill a worktree from outside it (e.g., from main repo)
- **`--detach`** — spawn teardown in background via `nohup` when session is inside the worktree being killed, so the calling session survives
- SKILL.md updated with Case A (remote kill) and Case B (self-kill) instructions

Fixes the bug where running `/ctx-kill-wt` from inside the target worktree destroyed the Claude Code session — `pwd` pointed at a deleted directory, all subsequent commands failed with `ENOENT`.

## Verification

| Claim | Command | Result |
|---|---|---|
| `--help` shows new flags | `kill-wt.sh --help` | Shows `--worktree <path>` and `--detach` |
| Main repo blocked (no args) | `kill-wt.sh` from main repo | `exit 2` — "target is the main worktree" |
| Main repo blocked (`--worktree` self-reference) | `--worktree <main-repo-path>` | `exit 2` — same block |
| Invalid path rejected | `--worktree /nonexistent/path` | `exit 2` — "not a valid git worktree" |
| `--worktree` remote kill works | Tested with throwaway worktree | `exit 0` — worktree removed, branch deleted |
| `--detach` background kill works | Tested with throwaway worktree | `detached=true`, log confirmed teardown completed |
| Session survives after kill | `pwd` after both kill modes | Returns valid main repo path |

## Test plan

- [ ] Create a worktree, kill it from main repo with `--worktree` — verify removal
- [ ] Create a worktree, `cd` into it, kill with `--detach` — verify background teardown + session survival
- [ ] Attempt to kill main repo (both no-args and `--worktree` pointing at main) — verify hard block
- [ ] Pass `--port` with `--detach` — verify port kill is forwarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)