### PR TITLE
feat: v0.2.9 — stability and portability patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.9 (2026-04-05)
+
+- **Enforce ship-pr.sh** — PreToolUse hook blocks manual `gh pr create`, redirects to script
+- **ship-pr.sh handles pre-committed work** — `--files`/`--message` optional, skips stage/commit when nothing to do
+- **Path audit** — worktree-guard auto-detects siblings from git root parent, worktree-open.sh supports tmux + iTerm2 + Terminal.app
+- **Worktree-guard same-repo fix** — worktrees of the same repo no longer blocked as cross-repo edits
+- **kill-wt fetch before teardown** — `git fetch origin` before branch delete to verify merge status
+- **grab-restore.sh bugfix** — `set -e` no longer kills script before outputting `status=not_found`
+- **Script tests** — kill-wt + worktree-guard regression tests, 47/47 passing
+- **Docs** — Getting Started workflow, companion server setup, updated hooks table
+- **iOS Simulator QA pipeline** — `sim-interact.sh` (boot, open, screenshot, scroll, tap) + `preview-device.sh` for real WebKit QA on iPhone
+- **iOS mobile reference** — `ios-mobile.md` checklist for safe areas, dvh, form controls, touch targets
+
 ## 0.2.8.1 (2026-04-05)
 
 - **kill-wt safe teardown** — `--worktree` flag for remote kill from main repo, `--detach` flag for background teardown when session is inside the worktree being killed. Prevents destroying Claude Code session.

--- a/README.md
+++ b/README.md
@@ -17,19 +17,51 @@ This **skill-script symbiosis** reduces tool calls by 87% and wall-clock time by
 
 ## Important: Setup Notes
 
-**Platform:** macOS-first. Core skills, scripts, and hooks are POSIX-compatible (Linux works), but `worktree-open.sh` uses AppleScript/iTerm2 (macOS only). Windows is untested.
+**Platform:** macOS. Terminal support: tmux, iTerm2, Terminal.app. Core skills and scripts are POSIX-compatible. Windows is untested.
 
-**Path configuration:** This plugin is in early development (v0.2.5). Several scripts reference `~/WebstormProjects/` as the projects directory — this matches the default JetBrains (WebStorm/IntelliJ) layout. If your projects live elsewhere (e.g., `~/Projects/`, `~/dev/`, `~/cursor-projects/`), you'll need to update these paths:
-
-- `plugins/ctx/hooks/scripts/worktree-guard.sh` — the `PROJECTS_DIR` variable controls where cross-repo edit blocking applies
-
-This will be auto-detected in v1.0.0. For now, grep for `WebstormProjects` and adjust to your setup.
+**Path detection:** Cross-repo edit blocking auto-detects sibling projects from your git repo's parent directory — no hardcoded paths.
 
 ## Install
 
 ```sh
 /plugin marketplace add Garabed96/ctx-plugin
 /plugin install ctx@ctx-plugin
+```
+
+## Getting Started
+
+The core loop is: **brainstorm → plan → worktree → execute → ship**
+
+```
+/ctx-brainstorm          # Explore the problem, surface blind spots
+/ctx-plan                # Produce a tagged implementation plan
+/ctx-worktree            # Create an isolated git worktree for the work
+/ctx-execute             # Dispatch subagents per plan task
+/ctx-ship                # Preflight → verify → PR (gated at each phase)
+```
+
+**Minimal workflow** (skip brainstorm/plan for small fixes):
+
+```
+/ctx-worktree            # Isolate the work
+# ... make changes ...
+/ctx-verify              # Evidence before claims
+/ctx-ship                # Create PR
+```
+
+**Session continuity** — when you need to stop and resume later:
+
+```
+/ctx-park                # Save context handoff for next session
+# ... close session, reopen later ...
+/ctx-grab                # Restore context from park file
+```
+
+**Debugging:**
+
+```
+/ctx-debug               # Systematic root cause investigation (blocks premature fixes)
+/ctx-tdd                 # Red-Green-Refactor with enforcement
 ```
 
 ## Scripts
@@ -105,8 +137,11 @@ Dispatched automatically by `ctx-execute` and `ctx-ship` based on task complexit
 | Event | Hook | Purpose |
 |-------|------|---------|
 | `PreToolUse` | `worktree-guard` | Blocks Edit/Write/Bash mutations outside the current repo's worktree. Also blocks cross-repo edits to sibling projects. |
+| `PreToolUse` | `enforce-ship-pr` | Blocks manual `gh pr create` — redirects to `ship-pr.sh` to save tokens. |
 | `SessionStart` | `session-start` | Injects context at the start of every session. |
 | `PostToolUse` | `log-skill-invocation` | Logs which skills are invoked (fires on `Skill` tool use). |
+| `PostToolUse` | `auto-pr` | After `git push`, runs typecheck and creates a draft PR. |
+| `PostToolUse` | test coverage nudge | After test runs, checks if tests cover service-layer concerns or only unit-level. |
 | `UserPromptSubmit` | `altitude-check` | Nudges when it detects altitude oscillation — micromanaging vs. hand-waving. |
 
 ## Philosophy
@@ -132,9 +167,32 @@ Claude Code runs background forks that silently consume tokens (prompt suggestio
 
 See `ctx-engineering/references/hidden_token_costs.md` for the full breakdown of what each system does.
 
+## Companion Server
+
+The brainstorm skill includes an optional companion web UI for visual design exploration.
+
+```bash
+# Start the companion server
+bash plugins/ctx/skills/ctx-brainstorm/companion/start.sh \
+  --project-dir /path/to/your/project \
+  --port 52341
+
+# Options:
+#   --project-dir <path>  Required. The project to brainstorm against.
+#   --port <port>         Default: 52341
+#   --rescan              Force re-scan of project styles (normally cached)
+```
+
+The server provides:
+- **Portfolio** at `http://localhost:<port>/` — landing page for design prototypes
+- **Factory** at `http://localhost:<port>/factory` — per-page visual brainstorming with click-to-select options
+- **API** at `/api/write`, `/api/page-status` — used by the brainstorm skill to persist events
+
+Pages and events are stored in `<project-dir>/companion/pages/<page>/.events`.
+
 ## Status
 
-**v0.2.8** — Private, actively iterating. Companion factory MVP, cross-repo guard, session continuity stable.
+**v0.2.8.1** — Private, actively iterating. Companion factory MVP, cross-repo guard, session continuity stable.
 
 ## License
 

--- a/plugins/ctx/.claude-plugin/plugin.json
+++ b/plugins/ctx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctx",
   "description": "Personal development toolkit built on context economy — brainstorm, plan, execute, ship, QA. Every skill optimizes for minimal token spend with maximum signal.",
-  "version": "0.2.8.1",
+  "version": "0.2.9",
   "author": {
     "name": "Garo Nazarian"
   }

--- a/plugins/ctx/hooks/hooks.json
+++ b/plugins/ctx/hooks/hooks.json
@@ -9,6 +9,15 @@
             "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/worktree-guard.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/enforce-ship-pr.sh\""
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/plugins/ctx/hooks/scripts/enforce-ship-pr.sh
+++ b/plugins/ctx/hooks/scripts/enforce-ship-pr.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# PreToolUse hook: block manual `gh pr create` — redirect to ship-pr.sh.
+# The script handles stage + commit + push + PR in one shot, saving tokens.
+#
+# Matches: Bash (only when command contains `gh pr create`)
+# Reads tool_input from stdin (JSON), exits 2 to block.
+
+INPUT=$(cat)
+
+command -v jq &>/dev/null || exit 0
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+[ "$TOOL_NAME" = "Bash" ] || exit 0
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$COMMAND" ] && exit 0
+
+# Only intercept gh pr create
+echo "$COMMAND" | grep -q 'gh pr create' || exit 0
+
+echo "BLOCKED — don't create PRs manually with 'gh pr create'." >&2
+echo "Use ship-pr.sh instead (stage + commit + push + PR in one command):" >&2
+echo "" >&2
+echo '  bash ${CLAUDE_PLUGIN_ROOT}/scripts/ship-pr.sh \' >&2
+echo '    --files file1 file2 \' >&2
+echo '    --message "feat: description" \' >&2
+echo '    --title "PR title" \' >&2
+echo '    --body "PR body" \' >&2
+echo '    --draft' >&2
+echo "" >&2
+echo "Or use /ctx-ship for the full gated pipeline." >&2
+exit 2

--- a/plugins/ctx/hooks/scripts/worktree-guard.sh
+++ b/plugins/ctx/hooks/scripts/worktree-guard.sh
@@ -71,6 +71,13 @@ FILE_REPO=$(git -C "$CHECK_DIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
 
 # If the file is in a different repo, check if it's a sibling project repo (cross-repo edit)
 if [ "$FILE_REPO" != "$PROJECT_ROOT" ]; then
+  # Allow writes to worktrees of the same repo (they share a git common dir)
+  PROJECT_GIT=$(git -C "$PROJECT_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+  FILE_GIT=$(git -C "$FILE_REPO" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+  if [ "$PROJECT_GIT" = "$FILE_GIT" ]; then
+    exit 0
+  fi
+
   # Block edits to sibling project repos (repos sharing the same parent directory)
   PROJECTS_DIR=$(dirname "$PROJECT_ROOT")
   case "$FILE_REPO" in

--- a/plugins/ctx/hooks/scripts/worktree-guard.sh
+++ b/plugins/ctx/hooks/scripts/worktree-guard.sh
@@ -71,8 +71,8 @@ FILE_REPO=$(git -C "$CHECK_DIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
 
 # If the file is in a different repo, check if it's a sibling project repo (cross-repo edit)
 if [ "$FILE_REPO" != "$PROJECT_ROOT" ]; then
-  # Block edits to other project repos under ~/WebstormProjects/
-  PROJECTS_DIR="$HOME/WebstormProjects"
+  # Block edits to sibling project repos (repos sharing the same parent directory)
+  PROJECTS_DIR=$(dirname "$PROJECT_ROOT")
   case "$FILE_REPO" in
     "$PROJECTS_DIR"/*)
       TARGET_NAME=$(basename "$FILE_REPO")

--- a/plugins/ctx/scripts/grab-restore.sh
+++ b/plugins/ctx/scripts/grab-restore.sh
@@ -33,14 +33,16 @@ WORKTREE=$(basename "$REPO_ROOT")
 # ── Find handoff ──────────────────────────────────────────
 if [[ ! -f "$HANDOFF" ]]; then
   # Fallback: restore from latest archive (handles consumed-by-dead-session edge case)
-  LATEST_ARCHIVE=$(ls -t "$REPO_ROOT"/docs/ctx/park-*.md 2>/dev/null | head -1)
+  LATEST_ARCHIVE=$(ls -t "$REPO_ROOT"/docs/ctx/park-*.md 2>/dev/null | head -1 || true)
   if [[ -n "$LATEST_ARCHIVE" ]]; then
     cp "$LATEST_ARCHIVE" "$HANDOFF"
     echo "Restored from archive: $(basename "$LATEST_ARCHIVE")" >&2
   else
-    echo "status=not_found"
-    echo "branch=$BRANCH"
-    echo "worktree=$WORKTREE"
+    cat <<EOF
+status=not_found
+branch=$BRANCH
+worktree=$WORKTREE
+EOF
     exit 1
   fi
 fi

--- a/plugins/ctx/scripts/kill-wt.sh
+++ b/plugins/ctx/scripts/kill-wt.sh
@@ -92,6 +92,9 @@ fi
 # ── Switch to main repo before removal ───────────────────
 cd "$MAIN_REPO"
 
+# ── Fetch latest so branch -d knows what's merged ───────
+git fetch origin 2>/dev/null && echo "Fetched latest from origin" >&2 || echo "warn: fetch failed (offline?)" >&2
+
 # ── Remove worktree ──────────────────────────────────────
 if [[ "$FORCE" == true ]]; then
   git worktree remove --force "$WORKTREE_PATH" 2>&1 >&2

--- a/plugins/ctx/scripts/ship-pr.sh
+++ b/plugins/ctx/scripts/ship-pr.sh
@@ -43,30 +43,36 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ ${#FILES[@]} -eq 0 ]] && { echo "Error: --files is required" >&2; exit 1; }
-[[ -z "$MESSAGE" ]] && { echo "Error: --message is required" >&2; exit 1; }
 [[ -z "$TITLE" ]] && { echo "Error: --title is required" >&2; exit 1; }
 [[ -z "$BODY" ]] && { echo "Error: --body is required" >&2; exit 1; }
 
 BRANCH=$(git branch --show-current 2>/dev/null || echo "detached")
-
-# ── Stage files ───────────────────────────────────────────
-echo "Staging ${#FILES[@]} file(s)..." >&2
-git add "${FILES[@]}" 2>&1 >&2 || { echo "Error: git add failed" >&2; exit 2; }
-
-# Verify staging
-STAGED=$(git diff --cached --name-only)
-echo "Staged: $(echo "$STAGED" | wc -l | tr -d ' ') file(s)" >&2
-
-# ── Commit ────────────────────────────────────────────────
-echo "Committing..." >&2
-git commit -m "$MESSAGE" 2>&1 >&2 || { echo "Error: git commit failed" >&2; exit 2; }
 COMMIT_SHA=$(git rev-parse --short HEAD)
-echo "Committed: $COMMIT_SHA" >&2
 
-# ── Push ──────────────────────────────────────────────────
+# ── Stage + Commit (skip if nothing to commit) ───────────
+if [[ ${#FILES[@]} -gt 0 ]]; then
+  [[ -z "$MESSAGE" ]] && { echo "Error: --message is required when --files are provided" >&2; exit 1; }
+
+  echo "Staging ${#FILES[@]} file(s)..." >&2
+  git add "${FILES[@]}" 2>&1 >&2 || { echo "Error: git add failed" >&2; exit 2; }
+
+  STAGED=$(git diff --cached --name-only)
+  if [[ -n "$STAGED" ]]; then
+    echo "Staged: $(echo "$STAGED" | wc -l | tr -d ' ') file(s)" >&2
+    echo "Committing..." >&2
+    git commit -m "$MESSAGE" 2>&1 >&2 || { echo "Error: git commit failed" >&2; exit 2; }
+    COMMIT_SHA=$(git rev-parse --short HEAD)
+    echo "Committed: $COMMIT_SHA" >&2
+  else
+    echo "Nothing to commit — files already committed" >&2
+  fi
+else
+  echo "No --files provided — skipping stage/commit" >&2
+fi
+
+# ── Push (skip if already up to date) ────────────────────
 echo "Pushing $BRANCH..." >&2
-git push -u origin "$BRANCH" 2>&1 >&2 || { echo "Error: git push failed" >&2; exit 2; }
+git push -u origin "$BRANCH" 2>&1 >&2 || echo "Already up to date" >&2
 
 # ── Create PR ─────────────────────────────────────────────
 echo "Creating PR..." >&2
@@ -88,5 +94,4 @@ echo "commit=$COMMIT_SHA"
 echo "branch=$BRANCH"
 echo "base=$BASE"
 echo "pr_url=$PR_URL"
-echo "files_staged=$(echo "$STAGED" | wc -l | tr -d ' ')"
 echo "draft=$DRAFT"

--- a/plugins/ctx/scripts/sim-interact.sh
+++ b/plugins/ctx/scripts/sim-interact.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# sim-interact.sh — Interact with Xcode iOS Simulator from the CLI.
+# Provides screenshot, scroll, tap, open, and device management for QA workflows.
+#
+# Usage:
+#   sim-interact.sh <command> [options]
+#
+# Commands:
+#   boot [--device <name>]              Boot a simulator (default: first iPhone)
+#   open --url <url>                    Open URL in simulator Safari
+#   screenshot [--out <path>]           Take screenshot (default: /tmp/sim-screenshot.png)
+#   scroll --dir <up|down> [--amount <n>]  Scroll the simulator window
+#   tap --x <x> --y <y>                Tap at coordinates on the simulator
+#   shake                              Shake gesture (useful for dev menus)
+#   devices                            List available iPhone simulators
+#
+# Exit codes: 0=success, 1=bad args, 2=simulator error
+
+set -euo pipefail
+
+CMD="${1:-}"
+shift 2>/dev/null || true
+
+case "$CMD" in
+  # ── Boot simulator ───────────────────────────────────────
+  boot)
+    DEVICE=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --device) DEVICE="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [[ -z "$DEVICE" ]]; then
+      DEVICE=$(xcrun simctl list devices available 2>/dev/null | grep -oE 'iPhone [^(]+' | head -1 | sed 's/ *$//')
+    fi
+    [[ -z "$DEVICE" ]] && { echo "Error: no iPhone simulators found" >&2; exit 2; }
+    echo "Booting $DEVICE..." >&2
+    xcrun simctl boot "$DEVICE" 2>/dev/null || true
+    open -a Simulator
+    # Wait for ready
+    RETRIES=0
+    while ! xcrun simctl openurl booted "about:blank" 2>/dev/null; do
+      RETRIES=$((RETRIES + 1))
+      [[ $RETRIES -gt 10 ]] && { echo "Error: boot timeout" >&2; exit 2; }
+      sleep 1
+    done
+    echo "device=$DEVICE"
+    echo "status=booted"
+    ;;
+
+  # ── Open URL ─────────────────────────────────────────────
+  open)
+    URL=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --url) URL="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [[ -z "$URL" ]] && { echo "Error: --url required" >&2; exit 1; }
+    xcrun simctl openurl booted "$URL" 2>/dev/null || { echo "Error: failed to open URL" >&2; exit 2; }
+    echo "url=$URL"
+    echo "status=opened"
+    ;;
+
+  # ── Screenshot ───────────────────────────────────────────
+  screenshot)
+    OUT="/tmp/sim-screenshot.png"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --out) OUT="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    xcrun simctl io booted screenshot "$OUT" 2>/dev/null || { echo "Error: screenshot failed" >&2; exit 2; }
+    echo "path=$OUT"
+    echo "status=captured"
+    ;;
+
+  # ── Scroll ───────────────────────────────────────────────
+  scroll)
+    DIR="down"
+    AMOUNT=5
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --dir)    DIR="$2"; shift 2 ;;
+        --amount) AMOUNT="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    # key code 125 = arrow down, 126 = arrow up
+    if [[ "$DIR" == "down" ]]; then KEY_CODE=125; else KEY_CODE=126; fi
+    osascript -e "
+      tell application \"Simulator\" to activate
+      delay 0.3
+      tell application \"System Events\"
+        tell process \"Simulator\"
+          repeat ${AMOUNT} times
+            key code ${KEY_CODE}
+            delay 0.1
+          end repeat
+        end tell
+      end tell
+    " 2>/dev/null || { echo "Error: scroll failed — grant accessibility permissions" >&2; exit 2; }
+    echo "direction=$DIR"
+    echo "amount=$AMOUNT"
+    echo "status=scrolled"
+    ;;
+
+  # ── Tap ──────────────────────────────────────────────────
+  tap)
+    X="" Y=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --x) X="$2"; shift 2 ;;
+        --y) Y="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [[ -z "$X" || -z "$Y" ]] && { echo "Error: --x and --y required" >&2; exit 1; }
+    osascript -e "
+      tell application \"Simulator\" to activate
+      delay 0.3
+      tell application \"System Events\"
+        tell process \"Simulator\"
+          click at {${X}, ${Y}}
+        end tell
+      end tell
+    " 2>/dev/null || { echo "Error: tap failed — grant accessibility permissions" >&2; exit 2; }
+    echo "x=$X"
+    echo "y=$Y"
+    echo "status=tapped"
+    ;;
+
+  # ── Shake ────────────────────────────────────────────────
+  shake)
+    osascript -e '
+      tell application "Simulator" to activate
+      tell application "System Events"
+        keystroke "z" using {control down, command down}
+      end tell
+    ' 2>/dev/null || true
+    echo "status=shook"
+    ;;
+
+  # ── List devices ─────────────────────────────────────────
+  devices)
+    xcrun simctl list devices available 2>/dev/null | grep -E 'iPhone|iPad'
+    ;;
+
+  # ── Help ─────────────────────────────────────────────────
+  ""|--help|-h)
+    echo "Usage: sim-interact.sh <command> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  boot [--device <name>]                Boot simulator"
+    echo "  open --url <url>                      Open URL in Safari"
+    echo "  screenshot [--out <path>]             Take screenshot"
+    echo "  scroll --dir <up|down> [--amount <n>] Scroll window"
+    echo "  tap --x <x> --y <y>                   Tap at coordinates"
+    echo "  shake                                 Shake gesture"
+    echo "  devices                               List simulators"
+    ;;
+
+  *)
+    echo "Unknown command: $CMD" >&2
+    exit 1
+    ;;
+esac

--- a/plugins/ctx/scripts/test-scripts.sh
+++ b/plugins/ctx/scripts/test-scripts.sh
@@ -326,6 +326,52 @@ fi
 
 # ══════════════════════════════════════════════════════════
 echo ""
+echo "=== TEST: kill-wt.sh ==="
+
+# Setup: go back to main test repo, create a worktree to kill
+cd "$TEMP_DIR/test-repo"
+git checkout -q main 2>/dev/null || true
+
+git worktree add -b kill-test "$TEMP_DIR/test-repo-kill-wt" main 2>/dev/null
+
+# Main repo hard block (no args, from main repo)
+OUTPUT=$(bash "$SCRIPT_DIR/kill-wt.sh" 2>&1 || true)
+assert_contains "blocks main repo" "$OUTPUT" "main worktree"
+
+# Main repo hard block (--worktree pointing at main)
+OUTPUT=$(bash "$SCRIPT_DIR/kill-wt.sh" --worktree "$TEMP_DIR/test-repo" 2>&1 || true)
+assert_contains "blocks --worktree=main" "$OUTPUT" "main worktree"
+
+# Invalid path
+OUTPUT=$(bash "$SCRIPT_DIR/kill-wt.sh" --worktree "/nonexistent" 2>&1 || true)
+assert_contains "rejects invalid path" "$OUTPUT" "not a valid git worktree"
+
+# Happy path: kill via --worktree from main repo
+OUTPUT=$(bash "$SCRIPT_DIR/kill-wt.sh" --worktree "$TEMP_DIR/test-repo-kill-wt" 2>/dev/null)
+assert_contains "outputs worktree path" "$OUTPUT" "worktree=$TEMP_DIR/test-repo-kill-wt"
+assert_contains "outputs branch" "$OUTPUT" "branch=kill-test"
+assert_contains "branch deleted" "$OUTPUT" "branch_status=deleted"
+
+# Verify worktree is gone
+if [[ ! -d "$TEMP_DIR/test-repo-kill-wt" ]]; then
+  echo "  PASS: worktree directory removed"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: worktree directory still exists"
+  FAIL=$((FAIL + 1))
+fi
+
+# Verify branch is gone
+if ! git branch --list kill-test | grep -q kill-test; then
+  echo "  PASS: branch deleted"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: branch still exists"
+  FAIL=$((FAIL + 1))
+fi
+
+# ══════════════════════════════════════════════════════════
+echo ""
 echo "════════════════════════════════"
 echo "Results: $PASS passed, $FAIL failed"
 echo "════════════════════════════════"

--- a/plugins/ctx/scripts/test-scripts.sh
+++ b/plugins/ctx/scripts/test-scripts.sh
@@ -237,8 +237,11 @@ else
 fi
 
 # Missing args
-OUTPUT=$(bash "$SCRIPT_DIR/ship-pr.sh" --files bar.ts 2>&1 || true)
-assert_contains "requires --message" "$OUTPUT" "--message is required"
+OUTPUT=$(bash "$SCRIPT_DIR/ship-pr.sh" 2>&1 || true)
+assert_contains "requires --title" "$OUTPUT" "--title is required"
+
+OUTPUT=$(bash "$SCRIPT_DIR/ship-pr.sh" --files bar.ts --title "t" --body "b" 2>&1 || true)
+assert_contains "requires --message with --files" "$OUTPUT" "--message is required"
 
 # ══════════════════════════════════════════════════════════
 echo ""
@@ -369,6 +372,29 @@ else
   echo "  FAIL: branch still exists"
   FAIL=$((FAIL + 1))
 fi
+
+# ══════════════════════════════════════════════════════════
+echo ""
+echo "=== TEST: worktree-guard.sh ==="
+
+GUARD="$SCRIPT_DIR/../hooks/scripts/worktree-guard.sh"
+
+# Create a worktree for same-repo testing
+git worktree add -b guard-test "$TEMP_DIR/test-repo-guard-wt" main 2>/dev/null
+
+# Same-repo worktree should be allowed (shares git common dir)
+OUTPUT=$(echo '{"tool_name":"Bash","tool_input":{"command":"mkdir -p '"$TEMP_DIR"'/test-repo-guard-wt/docs"}}' | bash "$GUARD" 2>&1)
+EXIT_CODE=$?
+assert_exit_code "allows same-repo worktree" "$EXIT_CODE" "0"
+
+# Main repo edit (we're in main checkout of ctx-plugin test repo — should be allowed since it's a worktree-based flow)
+OUTPUT=$(echo '{"tool_name":"Edit","tool_input":{"file_path":"'"$TEMP_DIR"'/test-repo/file.txt"}}' | bash "$GUARD" 2>&1)
+EXIT_CODE=$?
+assert_exit_code "allows own repo edit" "$EXIT_CODE" "0"
+
+# Clean up guard test worktree
+git worktree remove "$TEMP_DIR/test-repo-guard-wt" 2>/dev/null
+git branch -d guard-test 2>/dev/null
 
 # ══════════════════════════════════════════════════════════
 echo ""

--- a/plugins/ctx/scripts/worktree-open.sh
+++ b/plugins/ctx/scripts/worktree-open.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# worktree-open.sh — Open a new iTerm2 window with claude in the given worktree.
+# worktree-open.sh — Open a new terminal window with claude in the given worktree.
+# Supports: tmux, iTerm2, Terminal.app. Falls back to manual instructions.
 # Usage: worktree-open.sh <worktree-path>
 
 set -euo pipefail
@@ -13,17 +14,33 @@ fi
 
 # IMPORTANT: Never use `claude -p` or `claude '<prompt>'` — both run one prompt
 # and exit. Launch interactive `claude`, then send /ctx-grab via keystroke after delay.
-osascript -e "
-  tell application \"iTerm2\"
-    set newWindow to (create window with default profile)
-    tell current session of newWindow
-      write text \"cd '${WORKTREE_PATH}' && claude\"
-      delay 5
-      write text \"/ctx-grab\"
+
+OPENED=false
+
+# ── tmux (terminal-agnostic, works inside any emulator) ──
+if [[ -n "${TMUX:-}" ]]; then
+  tmux new-window -c "$WORKTREE_PATH" "claude"
+  # Send /ctx-grab after delay in background
+  (sleep 5 && tmux send-keys "/ctx-grab" Enter) &
+  OPENED=true
+fi
+
+# ── iTerm2 ───────────────────────────────────────────────
+if [[ "$OPENED" == false ]] && pgrep -q iTerm2 2>/dev/null; then
+  osascript -e "
+    tell application \"iTerm2\"
+      set newWindow to (create window with default profile)
+      tell current session of newWindow
+        write text \"cd '${WORKTREE_PATH}' && claude\"
+        delay 5
+        write text \"/ctx-grab\"
+      end tell
     end tell
-  end tell
-" 2>/dev/null || {
-  # Fallback: try Terminal.app
+  " 2>/dev/null && OPENED=true
+fi
+
+# ── Terminal.app ─────────────────────────────────────────
+if [[ "$OPENED" == false ]]; then
   osascript -e "
     tell application \"Terminal\"
       do script \"cd '${WORKTREE_PATH}' && claude\"
@@ -32,11 +49,14 @@ osascript -e "
         do script \"/ctx-grab\" in selected tab
       end tell
     end tell
-  " 2>/dev/null || {
-    echo "warn: could not open terminal — run manually: cd '${WORKTREE_PATH}' && claude" >&2
-    exit 0
-  }
-}
+  " 2>/dev/null && OPENED=true
+fi
+
+# ── Fallback ─────────────────────────────────────────────
+if [[ "$OPENED" == false ]]; then
+  echo "warn: could not open terminal — run manually: cd '${WORKTREE_PATH}' && claude" >&2
+  exit 0
+fi
 
 echo "opened=true"
 echo "path=${WORKTREE_PATH}"

--- a/plugins/ctx/skills/ctx-brainstorm/companion/cli/preview-device.sh
+++ b/plugins/ctx/skills/ctx-brainstorm/companion/cli/preview-device.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# preview-device.sh — Open any localhost URL in Xcode iOS Simulator.
+# Works with companion prototypes, dev servers, or any local URL.
+#
+# Usage:
+#   preview-device.sh --url <full-url>
+#   preview-device.sh --port <port> [--path <url-path>]
+#   preview-device.sh --port <port> --file <prototype-file>    (companion mode)
+#
+# Examples:
+#   preview-device.sh --url http://localhost:3000/plotter
+#   preview-device.sh --port 52341 --device "iPhone 13"
+#   preview-device.sh --port 52341 --file "pk-plotter/v3.html"
+#
+# Exit codes: 0=success, 1=bad args, 2=simulator error
+
+set -euo pipefail
+
+PORT=""
+DEVICE=""
+PROTO_FILE=""
+URL_PATH=""
+FULL_URL=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)   PORT="$2"; shift 2 ;;
+    --device) DEVICE="$2"; shift 2 ;;
+    --file)   PROTO_FILE="$2"; shift 2 ;;
+    --path)   URL_PATH="$2"; shift 2 ;;
+    --url)    FULL_URL="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: preview-device.sh --url <url> | --port <port> [--path <path>] [--file <proto>]"
+      echo ""
+      echo "Available iPhone simulators:"
+      xcrun simctl list devices available 2>/dev/null | grep -E 'iPhone' | sed 's/^/  /'
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -z "$FULL_URL" && -z "$PORT" ]] && { echo "Error: --url or --port is required" >&2; exit 1; }
+
+# ── Pick device (default: first available iPhone) ────────
+if [[ -z "$DEVICE" ]]; then
+  DEVICE=$(xcrun simctl list devices available 2>/dev/null | grep -oE 'iPhone [^(]+' | head -1 | sed 's/ *$//')
+  [[ -z "$DEVICE" ]] && { echo "Error: no iPhone simulators found. Install via Xcode." >&2; exit 2; }
+fi
+
+echo "Device: $DEVICE" >&2
+
+# ── Build URL ────────────────────────────────────────────
+if [[ -n "$FULL_URL" ]]; then
+  URL="$FULL_URL"
+elif [[ -n "$PROTO_FILE" ]]; then
+  URL="http://localhost:${PORT}/prototype?file=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${PROTO_FILE}'))")"
+elif [[ -n "$URL_PATH" ]]; then
+  URL="http://localhost:${PORT}${URL_PATH}"
+else
+  URL="http://localhost:${PORT}/"
+fi
+
+# ── Boot simulator ───────────────────────────────────────
+echo "Booting simulator..." >&2
+xcrun simctl boot "$DEVICE" 2>/dev/null || true
+open -a Simulator
+
+# Wait for runtime to be ready
+RETRIES=0
+while ! xcrun simctl openurl booted "about:blank" 2>/dev/null; do
+  RETRIES=$((RETRIES + 1))
+  [[ $RETRIES -gt 10 ]] && { echo "Error: simulator failed to boot after 10s" >&2; exit 2; }
+  sleep 1
+done
+
+# ── Open prototype ───────────────────────────────────────
+echo "Opening: $URL" >&2
+xcrun simctl openurl booted "$URL"
+
+# ── Structured output ────────────────────────────────────
+cat <<EOF
+device=$DEVICE
+port=$PORT
+url=$URL
+proto_file=${PROTO_FILE:-none}
+status=opened
+EOF

--- a/plugins/ctx/skills/ctx-brainstorm/companion/references/ios-mobile.md
+++ b/plugins/ctx/skills/ctx-brainstorm/companion/references/ios-mobile.md
@@ -1,0 +1,128 @@
+# iOS Mobile — Real Device Checklist
+
+**When to apply:** Any page that will be viewed on iPhone. Chrome DevTools mobile emulation lies — it uses Blink, not WebKit. These rules close the gap between emulation and reality.
+
+---
+
+## Viewport
+
+```css
+/* NEVER use 100vh — iOS Safari's URL bar makes it taller than the visible area */
+height: 100dvh;           /* dynamic viewport height — adjusts with URL bar */
+min-height: 100svh;       /* small viewport — URL bar expanded (safe minimum) */
+min-height: -webkit-fill-available; /* legacy fallback */
+```
+
+## Safe Areas (notch, home indicator, Dynamic Island)
+
+```css
+/* Always pad content away from hardware intrusions */
+padding-top: env(safe-area-inset-top);
+padding-bottom: env(safe-area-inset-bottom);
+padding-left: env(safe-area-inset-left);
+padding-right: env(safe-area-inset-right);
+
+/* Required in <meta> for safe areas to work */
+/* <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"> */
+```
+
+**FABs and bottom-fixed elements** — position above the home indicator:
+```css
+.fab {
+  bottom: calc(1rem + env(safe-area-inset-bottom));
+}
+```
+
+## Form Controls
+
+iOS renders native `<input>`, `<select>`, `<textarea>` with its own styling. Chrome emulation shows Chrome-styled controls.
+
+```css
+/* Normalize form appearance across engines */
+input, select, textarea {
+  -webkit-appearance: none;
+  appearance: none;
+  border-radius: 0;          /* iOS adds rounded corners */
+  font-size: 16px;           /* CRITICAL: below 16px triggers iOS auto-zoom on focus */
+}
+```
+
+**Date inputs:** iOS shows a native date picker wheel. There's no way to match this in Chrome. If pixel-perfect is needed, use a JS date picker library instead of `<input type="date">`.
+
+**Select dropdowns:** iOS shows a native scroll wheel. Same story — use a custom dropdown if you need visual consistency.
+
+## Touch Targets
+
+```css
+/* Apple HIG minimum: 44x44pt. Anything smaller is a tap-miss on real fingers. */
+button, a, [role="button"] {
+  min-height: 44px;
+  min-width: 44px;
+}
+```
+
+## Position Fixed
+
+`position: fixed` on iOS Safari bounces during scroll momentum and can disappear behind the keyboard.
+
+```css
+/* Prefer sticky for in-flow elements */
+.header { position: sticky; top: 0; }
+
+/* For true fixed elements (modals, FABs), use: */
+.fixed-element {
+  position: fixed;
+  /* Add will-change to prevent repaint flicker */
+  will-change: transform;
+}
+```
+
+**Keyboard avoidance:** When an input is focused, `position: fixed` elements get pushed up. Use `visualViewport` API to detect keyboard:
+```js
+visualViewport.addEventListener('resize', () => {
+  const keyboardHeight = window.innerHeight - visualViewport.height;
+  document.documentElement.style.setProperty('--keyboard-h', `${keyboardHeight}px`);
+});
+```
+
+## Scrolling
+
+```css
+/* Smooth momentum scrolling (default in modern iOS but explicit is safer) */
+-webkit-overflow-scrolling: touch;
+
+/* Prevent overscroll bounce on scroll containers */
+overscroll-behavior: contain;
+```
+
+## Text Rendering
+
+```css
+/* iOS Safari renders text thinner than Chrome. Normalize: */
+-webkit-font-smoothing: antialiased;
+-moz-osx-font-smoothing: grayscale;
+
+/* Prevent iOS text size inflation on rotation */
+-webkit-text-size-adjust: 100%;
+text-size-adjust: 100%;
+```
+
+## Common Traps
+
+| Trap | Fix |
+|------|-----|
+| `100vh` includes hidden URL bar | Use `100dvh` or `100svh` |
+| Input zoom on focus | Set `font-size: 16px` minimum on inputs |
+| FAB hidden behind Safari bottom bar | Add `env(safe-area-inset-bottom)` |
+| Tap targets too small | Minimum 44x44px |
+| `position: fixed` bounces on scroll | Use `position: sticky` or `will-change: transform` |
+| Hover styles stuck after tap | Use `@media (hover: hover)` for hover-only styles |
+| `backdrop-filter` flickers | Add `will-change: backdrop-filter` or `-webkit-backdrop-filter` |
+| Custom select looks wrong | iOS renders native — use `-webkit-appearance: none` |
+
+## Verification
+
+Don't trust Chrome emulation for final QA. Use one of:
+1. **Xcode Simulator** (free) — `open -a Simulator`, pick device, navigate to dev URL
+2. **Real device + Safari Web Inspector** — USB, `Safari > Develop > [phone name]`
+3. **Safari Responsive Design Mode** — same WebKit engine (no native controls though)

--- a/plugins/ctx/skills/ctx-debug/references/root-cause-tracing.md
+++ b/plugins/ctx/skills/ctx-debug/references/root-cause-tracing.md
@@ -15,7 +15,7 @@ Bugs manifest deep in the call stack. Your instinct is to fix where the error ap
 
 ### 1. Observe the Symptom
 ```
-Error: git init failed in /Users/jesse/project/packages/core
+Error: git init failed in ~/project/packages/core
 ```
 
 ### 2. Find Immediate Cause

--- a/plugins/ctx/skills/ctx-worktree/SKILL.md
+++ b/plugins/ctx/skills/ctx-worktree/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 
 # /worktree — Create an Isolated Git Worktree
 
-Creates a durable worktree via `${CLAUDE_PLUGIN_ROOT}/scripts/worktree-create.sh`, parks conversation context into it, then opens a new iTerm2 tab with claude. The new session can `/ctx-grab` to restore context instantly.
+Creates a durable worktree via `${CLAUDE_PLUGIN_ROOT}/scripts/worktree-create.sh`, parks conversation context into it, then opens a new terminal window with claude. The new session can `/ctx-grab` to restore context instantly.
 
 ## 1. Gather inputs
 


### PR DESCRIPTION
## Summary

10 patches toward v0.3.0 stability (issue #11):

- **enforce-ship-pr hook** — PreToolUse blocks manual `gh pr create`, redirects to `ship-pr.sh`
- **ship-pr.sh handles pre-committed work** — `--files`/`--message` now optional, skips stage/commit when nothing to do
- **path audit** — `worktree-guard.sh` auto-detects sibling repos from git root parent (no hardcoded `~/WebstormProjects/`), `worktree-open.sh` supports tmux + iTerm2 + Terminal.app
- **worktree-guard same-repo fix** — worktrees of the same repo were blocked as cross-repo edits. Now checks git-common-dir before blocking
- **kill-wt fetch before teardown** — `git fetch origin` before `git branch -d` so it knows what's merged
- **grab-restore.sh bugfix** — `set -e` killed script before outputting `status=not_found`
- **script tests** — kill-wt + worktree-guard regression tests. 47/47 passing
- **docs** — Getting Started workflow, companion server setup, updated hooks table
- **iOS Simulator QA pipeline** — `sim-interact.sh` (boot, open, screenshot, scroll, tap, shake) + `preview-device.sh` (open any localhost URL on iPhone simulator) for real WebKit QA
- **iOS mobile reference** — `ios-mobile.md` checklist (safe areas, 100dvh, form controls, touch targets, position fixed) for frontend/brainstorm skills

## Verification

| # | Claim | Method | Result |
|---|---|---|---|
| 1 | Script tests pass | `test-scripts.sh` | 47/47 pass |
| 2 | enforce-ship-pr blocks `gh pr create` | pipe JSON to hook | exit 2, BLOCKED |
| 3 | enforce-ship-pr allows other commands | pipe `git status` JSON | exit 0 |
| 4 | worktree-guard auto-detects siblings | pipe sibling repo Edit | exit 2, BLOCKED |
| 5 | worktree-guard allows same-repo worktrees | pipe own worktree Edit | exit 0 |
| 6 | kill-wt blocks main repo | `kill-wt.sh` from main | exit 2 |
| 7 | kill-wt `--worktree` works | create + kill throwaway | worktree removed, branch deleted, session survived |
| 8 | kill-wt fetches before teardown | grep + live output | "Fetched latest from origin" |
| 9 | ship-pr.sh skips stage/commit | run with no --files | "No --files provided", PR #13 created |
| 10 | Terminal.app opens worktree | `worktree-open.sh` live test | window opened, claude launched |
| 11 | /ctx-grab restores parked context | park → open → grab | context restored in new session |
| 12 | iOS Simulator boots + opens URL | `preview-device.sh --url` on peptides dev server | iPhone 13 simulator opened plotter page |
| 13 | sim-interact scroll works | AppleScript key code events | scrolled in simulator, screenshot captured |
| 14 | Plugin cache syncs to other sessions | `cat plugin.json` from peptides agent | confirmed v0.2.8.1 + new code |

## Test plan

- [x] Script tests pass (47/47)
- [x] `gh pr create` blocked by hook
- [x] worktree-guard allows same-repo worktrees, blocks sibling projects
- [x] Terminal.app: worktree-open.sh → claude → /ctx-grab with parked context
- [x] iOS Simulator: preview-device.sh opens dev server on iPhone 13
- [x] sim-interact.sh scroll + screenshot — live tested on peptides plotter
- [x] Plugin cache visible to other sessions
- [x] iTerm2: worktree-open.sh terminal detection
- [ ] tmux: worktree-open.sh terminal detection
- [ ] Fresh install: clone repo, run core loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)