### PR TITLE
fix: terminal detection in worktree-open.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.9.1 (2026-04-06)
+
+- **Terminal detection fix** — `worktree-open.sh` now uses `$TERM_PROGRAM` env var to detect the current terminal emulator instead of `pgrep`. Prevents silent fall-through from iTerm2 to Terminal.app when AppleScript permissions block automation.
+
 ## 0.2.9 (2026-04-05)
 
 - **Enforce ship-pr.sh** — PreToolUse hook blocks manual `gh pr create`, redirects to script

--- a/plugins/ctx/.claude-plugin/plugin.json
+++ b/plugins/ctx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctx",
   "description": "Personal development toolkit built on context economy — brainstorm, plan, execute, ship, QA. Every skill optimizes for minimal token spend with maximum signal.",
-  "version": "0.2.9",
+  "version": "0.2.9.1",
   "author": {
     "name": "Garo Nazarian"
   }

--- a/plugins/ctx/scripts/worktree-open.sh
+++ b/plugins/ctx/scripts/worktree-open.sh
@@ -16,6 +16,7 @@ fi
 # and exit. Launch interactive `claude`, then send /ctx-grab via keystroke after delay.
 
 OPENED=false
+TERM_APP="${TERM_PROGRAM:-}"
 
 # ── tmux (terminal-agnostic, works inside any emulator) ──
 if [[ -n "${TMUX:-}" ]]; then
@@ -23,10 +24,9 @@ if [[ -n "${TMUX:-}" ]]; then
   # Send /ctx-grab after delay in background
   (sleep 5 && tmux send-keys "/ctx-grab" Enter) &
   OPENED=true
-fi
 
-# ── iTerm2 ───────────────────────────────────────────────
-if [[ "$OPENED" == false ]] && pgrep -q iTerm2 2>/dev/null; then
+# ── iTerm2 (prefer env var, fall back to process check) ──
+elif [[ "$TERM_APP" == "iTerm.app" ]] || pgrep -q iTerm2 2>/dev/null; then
   osascript -e "
     tell application \"iTerm2\"
       set newWindow to (create window with default profile)
@@ -37,10 +37,9 @@ if [[ "$OPENED" == false ]] && pgrep -q iTerm2 2>/dev/null; then
       end tell
     end tell
   " 2>/dev/null && OPENED=true
-fi
 
 # ── Terminal.app ─────────────────────────────────────────
-if [[ "$OPENED" == false ]]; then
+elif [[ "$TERM_APP" == "Apple_Terminal" ]] || [[ -z "$TERM_APP" ]]; then
   osascript -e "
     tell application \"Terminal\"
       do script \"cd '${WORKTREE_PATH}' && claude\"


### PR DESCRIPTION
## Summary

- `worktree-open.sh` now uses `$TERM_PROGRAM` env var to detect the current terminal emulator instead of `pgrep -q iTerm2`
- Changed sequential `if/if/if` to `if/elif/elif` to prevent silent fall-through when AppleScript fails
- Bumps version to `0.2.9.1`

## Problem

When running from iTerm2, the script detected iTerm2 via `pgrep` (process was running), but the AppleScript automation failed silently (`2>/dev/null`). The sequential `if` blocks meant it fell through to Terminal.app — opening a new window in the wrong emulator.

## Fix

`$TERM_PROGRAM` is set by the terminal emulator itself:
- iTerm2 → `iTerm.app`
- Terminal.app → `Apple_Terminal`
- tmux → inherits outer terminal's value

This tells you which terminal the **current session** is in, not just what's installed. `pgrep` kept as fallback for edge cases where the env var isn't set.

## Test plan

- [x] Verified `worktree-open.sh` opens in iTerm2 when run from iTerm2
- [ ] Verify Terminal.app fallback still works when `TERM_PROGRAM` is unset
- [ ] Verify tmux path still works when `$TMUX` is set