### PR TITLE
v0.2.9.2: factory rename + main-repo-rooted pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.9.2 (2026-04-07)
+
+- **Factory rename** — `companion/pages/` → `factory/pages/`, `companion/style-profile.json` → `factory/style-profile.json`. Plugin interface file at project root (`companion.config.js`) unchanged.
+- **Main-repo-rooted pages** — factory pages now live at the main repo root, not per-worktree. All worktrees of a project share one portfolio. Server auto-resolves via `git rev-parse --git-common-dir` with fallback to `--project-dir` for non-git projects.
+- **Auto-setup** — `factory/pages/` is created on first server start. No manual setup needed per project.
+- **Migration required** — existing users: `mv <main-repo>/companion <main-repo>/factory` once. Per-worktree `companion/` dirs become orphaned and can be deleted.
+
 ## 0.2.9.1 (2026-04-06)
 
 - **Terminal detection fix** — `worktree-open.sh` now uses `$TERM_PROGRAM` env var to detect the current terminal emulator instead of `pgrep`. Prevents silent fall-through from iTerm2 to Terminal.app when AppleScript permissions block automation.

--- a/plugins/ctx/.claude-plugin/plugin.json
+++ b/plugins/ctx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctx",
   "description": "Personal development toolkit built on context economy — brainstorm, plan, execute, ship, QA. Every skill optimizes for minimal token spend with maximum signal.",
-  "version": "0.2.9.1",
+  "version": "0.2.9.2",
   "author": {
     "name": "Garo Nazarian"
   }

--- a/plugins/ctx/scripts/ship-pr.sh
+++ b/plugins/ctx/scripts/ship-pr.sh
@@ -83,6 +83,7 @@ fi
 
 PR_URL=$(gh pr create \
   --base "$BASE" \
+  --head "$BRANCH" \
   --title "$TITLE" \
   --body "$BODY" \
   $DRAFT_FLAG 2>&1) || { echo "Error: gh pr create failed" >&2; echo "$PR_URL" >&2; exit 3; }

--- a/plugins/ctx/skills/ctx-brainstorm/companion/cli/scan-styles.js
+++ b/plugins/ctx/skills/ctx-brainstorm/companion/cli/scan-styles.js
@@ -9,7 +9,7 @@
  *   2. CSS custom properties from :root blocks
  *   3. package.json for component libraries + frameworks
  *
- * Outputs: <project-dir>/companion/style-profile.json
+ * Outputs: <project-dir>/factory/style-profile.json
  */
 
 "use strict";
@@ -771,7 +771,7 @@ function main() {
   const profile = buildProfile(tailwindResult, cssResult, pkgResult);
 
   // 5. Write output
-  const outputDir = path.join(projectDir, "companion");
+  const outputDir = path.join(projectDir, "factory");
   fs.mkdirSync(outputDir, { recursive: true });
   const outputPath = path.join(outputDir, "style-profile.json");
   fs.writeFileSync(outputPath, JSON.stringify(profile, null, 2) + "\n");

--- a/plugins/ctx/skills/ctx-brainstorm/companion/factory.html
+++ b/plugins/ctx/skills/ctx-brainstorm/companion/factory.html
@@ -757,7 +757,7 @@ function renderSlots(slots) {
     var ph = document.getElementById('preview-placeholder');
     if (ph) {
       ph.style.display = '';
-      document.getElementById('preview-placeholder-msg').textContent = 'No prototype files found in companion/pages/';
+      document.getElementById('preview-placeholder-msg').textContent = 'No prototype files found in factory/pages/';
     }
     return;
   }

--- a/plugins/ctx/skills/ctx-brainstorm/companion/server.js
+++ b/plugins/ctx/skills/ctx-brainstorm/companion/server.js
@@ -79,6 +79,32 @@ if (!screenDir) {
 
 fs.mkdirSync(screenDir, { recursive: true });
 
+// ========== Pages Root Resolution ==========
+// Factory pages live in the MAIN repo, not per-worktree. So all worktrees of a
+// project share one portfolio. Detect via `git rev-parse --git-common-dir`:
+// - Main repo → outputs ".git" (relative) → parent = projectDir
+// - Worktree  → outputs absolute path to main/.git → parent = main repo root
+// Fall back to projectDir if not a git repo.
+let pagesRoot = projectDir;
+if (projectDir) {
+  try {
+    const { execFileSync } = require("child_process");
+    const commonDir = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+      cwd: projectDir,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString().trim();
+    const resolvedCommon = path.resolve(projectDir, commonDir);
+    pagesRoot = path.dirname(resolvedCommon);
+  } catch {
+    // Not a git repo or git unavailable — use projectDir
+  }
+  // Auto-create factory dirs on first run
+  fs.mkdirSync(path.join(pagesRoot, "factory/pages"), { recursive: true });
+  if (pagesRoot !== projectDir) {
+    console.error("[factory] Worktree detected — pages root: " + pagesRoot);
+  }
+}
+
 const frameTemplate = fs.readFileSync(
   path.join(__dirname, "frame-template.html"),
   "utf8"
@@ -170,9 +196,9 @@ function handleMessage(text) {
   let event;
   try { event = JSON.parse(text); } catch { return; }
   if (event.type) {
-    // Per-page events: persist to companion/pages/<page>/.events when page is set
-    if (event.page && projectDir) {
-      const pageEventsFile = path.join(projectDir, "companion/pages", event.page, ".events");
+    // Per-page events: persist to factory/pages/<page>/.events when page is set
+    if (event.page && pagesRoot) {
+      const pageEventsFile = path.join(pagesRoot, "factory/pages", event.page, ".events");
       if (fs.existsSync(path.dirname(pageEventsFile))) {
         fs.appendFileSync(pageEventsFile, JSON.stringify(event) + "\n");
         return;
@@ -218,8 +244,8 @@ fs.watch(screenDir, (eventType, filename) => {
   }, 100));
 });
 
-if (projectDir) {
-  const pagesDir = path.join(projectDir, "companion/pages");
+if (pagesRoot) {
+  const pagesDir = path.join(pagesRoot, "factory/pages");
   fs.mkdirSync(pagesDir, { recursive: true });
   fs.watch(pagesDir, { recursive: true }, (eventType, filename) => {
     if (!filename || !filename.endsWith(".html")) return;
@@ -237,10 +263,10 @@ if (projectDir) {
 let _styleProfileCache = null;
 
 function readStyleProfile() {
-  if (!projectDir) return null;
+  if (!pagesRoot) return null;
   if (_styleProfileCache !== null) return _styleProfileCache;
 
-  const profilePath = path.join(projectDir, "companion/style-profile.json");
+  const profilePath = path.join(pagesRoot, "factory/style-profile.json");
   if (!fs.existsSync(profilePath)) return null;
 
   try {
@@ -395,13 +421,13 @@ function serveFactory(res, targetPage) {
 }
 
 function servePrototype(res, filePath) {
-  if (!projectDir) {
+  if (!pagesRoot) {
     res.writeHead(400, { "Content-Type": "text/plain" });
     res.end("No --project-dir configured");
     return;
   }
-  const resolved = path.resolve(projectDir, "companion/pages", filePath);
-  if (!resolved.startsWith(path.resolve(projectDir, "companion/pages"))) {
+  const resolved = path.resolve(pagesRoot, "factory/pages", filePath);
+  if (!resolved.startsWith(path.resolve(pagesRoot, "factory/pages"))) {
     res.writeHead(403, { "Content-Type": "text/plain" });
     res.end("Forbidden");
     return;
@@ -450,8 +476,8 @@ function serveBrainstorm(res) {
 // ========== Slot Scanner ==========
 
 function scanSlots() {
-  if (!projectDir) return [];
-  const prototypesDir = path.join(projectDir, "companion/pages");
+  if (!pagesRoot) return [];
+  const prototypesDir = path.join(pagesRoot, "factory/pages");
   if (!fs.existsSync(prototypesDir)) return [];
 
   const slots = new Map();
@@ -496,7 +522,7 @@ function scanSlots() {
 // ========== Auto-Versioning ==========
 
 function nextVersionPath(page) {
-  const pagesDir = path.join(projectDir, "companion/pages", page);
+  const pagesDir = path.join(pagesRoot, "factory/pages", page);
   fs.mkdirSync(pagesDir, { recursive: true });
   const existing = fs.readdirSync(pagesDir).filter(f => f.endsWith(".html"));
   let maxVersion = 0;
@@ -619,8 +645,8 @@ function handlePageStatus(req, res) {
 
     // Read per-page .events for selected option
     let selectedOption = null;
-    if (projectDir) {
-      const eventsPath = path.join(projectDir, "companion/pages", page, ".events");
+    if (pagesRoot) {
+      const eventsPath = path.join(pagesRoot, "factory/pages", page, ".events");
       if (fs.existsSync(eventsPath)) {
         const lines = fs.readFileSync(eventsPath, "utf8").trim().split("\n").filter(Boolean);
         for (let i = lines.length - 1; i >= 0; i--) {
@@ -637,8 +663,8 @@ function handlePageStatus(req, res) {
 
     // Last modified from latest file
     let lastModified = null;
-    if (latestFile && projectDir) {
-      const filePath = path.join(projectDir, "companion/pages", latestFile);
+    if (latestFile && pagesRoot) {
+      const filePath = path.join(pagesRoot, "factory/pages", latestFile);
       if (fs.existsSync(filePath)) {
         lastModified = fs.statSync(filePath).mtime.toISOString();
       }
@@ -708,12 +734,12 @@ const server = http.createServer((req, res) => {
       jsonResponse(res, 200, profile);
     }
   } else if (parsed.pathname === "/api/scan" && req.method === "POST") {
-    if (!projectDir) {
+    if (!pagesRoot) {
       jsonResponse(res, 400, { error: "No --project-dir configured" });
     } else {
       const { execFile } = require("child_process");
       const scanScript = path.join(__dirname, "cli/scan-styles.js");
-      execFile(process.execPath, [scanScript, "--project-dir", projectDir], (err, stdout, stderr) => {
+      execFile(process.execPath, [scanScript, "--project-dir", pagesRoot], (err, stdout, stderr) => {
         if (err) {
           jsonResponse(res, 500, { error: err.message, stderr });
         } else {

--- a/plugins/ctx/skills/ctx-brainstorm/companion/start.sh
+++ b/plugins/ctx/skills/ctx-brainstorm/companion/start.sh
@@ -26,13 +26,23 @@ mkdir -p "$SCREEN_DIR"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Style profile check
-STYLE_PROFILE="$PROJECT_DIR/companion/style-profile.json"
+# Resolve pages root — main repo if in a worktree, else PROJECT_DIR
+PAGES_ROOT="$PROJECT_DIR"
+COMMON_DIR=$(cd "$PROJECT_DIR" && git rev-parse --git-common-dir 2>/dev/null)
+if [ -n "$COMMON_DIR" ]; then
+  case "$COMMON_DIR" in
+    /*) PAGES_ROOT=$(dirname "$COMMON_DIR") ;;  # Absolute → worktree case
+    *)  PAGES_ROOT="$PROJECT_DIR" ;;            # Relative (.git) → main repo case
+  esac
+fi
+
+# Style profile check (pagesRoot = main repo, shared across worktrees)
+STYLE_PROFILE="$PAGES_ROOT/factory/style-profile.json"
 if [ "$RESCAN" -eq 1 ] || [ ! -f "$STYLE_PROFILE" ]; then
-  echo "[companion] Scanning styles..." >&2
-  node "$SCRIPT_DIR/cli/scan-styles.js" --project-dir "$PROJECT_DIR"
+  echo "[factory] Scanning styles..." >&2
+  node "$SCRIPT_DIR/cli/scan-styles.js" --project-dir "$PAGES_ROOT"
 else
-  echo "[companion] Using existing style profile" >&2
+  echo "[factory] Using existing style profile at $STYLE_PROFILE" >&2
 fi
 
 # Start server in background


### PR DESCRIPTION
## Summary

- Rename `companion/pages/` → `factory/pages/` and `companion/style-profile.json` → `factory/style-profile.json` in all plugin-generated paths.
- Pages now live at the **main repo root**, not per-worktree. All worktrees of a project share one factory portfolio.
- Main repo detected via `git rev-parse --git-common-dir` (fallback: `--project-dir` for non-git projects).
- `factory/pages/` auto-created on first server start.
- `companion.config.js` (protosmith plugin interface at project root) unchanged — separate concept.
- **Bonus fix:** ship-pr.sh now passes explicit `--head` flag to avoid auto-detection failures when untracked files are present.

## Why

Per-worktree pages meant iterations scattered across branches. When switching worktrees, previously-saved designs became invisible. Discovered while working on plotter UX overhaul — mobile-nav/research-insights iterations were stuck in another worktree. Main-repo-rooted pages give one shared portfolio per project.

## Migration

Existing users run once:
\`\`\`bash
mv <main-repo>/companion <main-repo>/factory
\`\`\`

Per-worktree \`companion/\` dirs become orphaned after the upgrade.

## Test plan

- [ ] Start server from a worktree — \`[factory] Worktree detected\` appears
- [ ] \`/api/slots\` returns pages from the main repo's \`factory/pages/\`
- [ ] \`POST /api/write\` creates files at main repo root
- [ ] ship-pr.sh now succeeds when untracked files exist in working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)