### PR TITLE
fix(brainstorm-ss): verify before flagging in spec reviewer (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.9.3 (2026-04-07)
+
+- **Spec reviewer verification protocol** — `ctx-brainstorm-ss` reviewer now verifies claims before flagging. Unverifiable claims go to Recommendations, not Issues. Three sentences added to the existing Calibration section in `spec-reviewer-prompt.md` — no new sections, no new vocabulary. Fixes false positives where reviewers escalated unverified theoretical risks (#17).
+
 ## 0.2.9.2 (2026-04-07)
 
 - **Factory rename** — `companion/pages/` → `factory/pages/`, `companion/style-profile.json` → `factory/style-profile.json`. Plugin interface file at project root (`companion.config.js`) unchanged.

--- a/plugins/ctx/.claude-plugin/plugin.json
+++ b/plugins/ctx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctx",
   "description": "Personal development toolkit built on context economy — brainstorm, plan, execute, ship, QA. Every skill optimizes for minimal token spend with maximum signal.",
-  "version": "0.2.9.2",
+  "version": "0.2.9.3",
   "author": {
     "name": "Garo Nazarian"
   }

--- a/plugins/ctx/skills/ctx-brainstorm-ss/references/spec-reviewer-prompt.md
+++ b/plugins/ctx/skills/ctx-brainstorm-ss/references/spec-reviewer-prompt.md
@@ -26,6 +26,10 @@ prompt: |
   interpreted two different ways — those are issues. Minor wording improvements,
   stylistic preferences, and "sections less detailed than others" are not.
 
+  **Verify before flagging.** If you can't verify a claim against the code, file, or
+  data, it goes in Recommendations, not Issues. Say "I don't know" — that's the
+  right answer, not a failure.
+
   Approve unless there are serious gaps that would lead to a flawed plan.
 
   ## Output Format


### PR DESCRIPTION
Reviewer subagents were escalating unverified theoretical risks to "Issues"
(blocking) instead of "Recommendations" (advisory). Three sentences added to
the existing Calibration section — no new sections, no new vocabulary, reuses
the existing Issues/Recommendations split.

Fixes #17.
