### PR TITLE
docs: maintainer notes + fix README factory routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,10 @@ bash plugins/ctx/skills/ctx-brainstorm/factory/start.sh \
 ```
 
 The server provides:
-- **Portfolio** at `http://localhost:<port>/` — landing page for design prototypes
-- **Factory** at `http://localhost:<port>/factory` — per-page visual brainstorming with click-to-select options
-- **API** at `/api/write`, `/api/page-status` — used by the brainstorm skill to persist events
+- **Portfolio** at `http://localhost:<port>/factory` — landing page listing all prototype pages
+- **Factory editor** at `http://localhost:<port>/factory/<page>` — per-page visual brainstorming with click-to-select options, style controls, and version pills
+- **Brainstorm preview** at `http://localhost:<port>/` — ephemeral view of the newest HTML from the current brainstorm session
+- **API** at `/api/write`, `/api/page-status`, `/api/slots`, `/api/style-profile` — used by the brainstorm skill to persist events and query state
 
 Pages and events are stored in `<project-dir>/factory/pages/<page>/.events`.
 

--- a/docs/maintainer-notes.md
+++ b/docs/maintainer-notes.md
@@ -1,0 +1,51 @@
+# Maintainer Notes
+
+Conventions and landmines for anyone (human or Claude) working on ctx-plugin itself. Not for plugin users — for the person maintaining the plugin source.
+
+## Release tagging
+
+**Starting v0.2.9.4, release tags are annotated (with a description), not lightweight.** Earlier tags (v0.2.4 through v0.2.9.3) are lightweight — leave them alone, but match the new style going forward.
+
+When cutting a release:
+
+1. Bump `plugins/ctx/.claude-plugin/plugin.json` and add a `CHANGELOG.md` entry in the same commit
+2. Merge the PR
+3. Tag the **merge commit** on `main` with an annotated tag:
+   ```bash
+   git fetch origin main
+   git tag -a vX.Y.Z <merge-sha> -m "vX.Y.Z — one-line summary
+
+   <body: per-ticket or per-change bullets, same structure as the CHANGELOG entry>
+
+   PR: https://github.com/Garabed96/ctx-plugin/pull/<n>"
+   git push origin vX.Y.Z
+   ```
+4. The tag body should mirror the merged PR body — not the raw commit list, but the human-readable summary of what changed and why.
+
+If you need to replace a tag that's already on the remote (e.g. to add a message to a tag that was pushed as lightweight), delete both locally and remote-side before re-creating:
+```bash
+git push origin :refs/tags/vX.Y.Z
+git tag -d vX.Y.Z
+git tag -a vX.Y.Z <sha> -m "..."
+git push origin vX.Y.Z
+```
+
+## Landmines (things that look like mistakes but aren't)
+
+- **`companion.config.js`** — despite the `companion` → `factory` rename completed in v0.2.9.4, the plugin interface file at project root stays named `companion.config.js`. This is intentional per the v0.2.9.2 release notes. The literal string `companion.config.js` must be preserved in any source that references it (currently `plugins/ctx/skills/ctx-brainstorm/factory/server.js:117,133,587`).
+- **`factory/` at repo root is tracked but sparse-excluded in worktrees** — new worktrees created by `plugins/ctx/scripts/worktree-create.sh` apply `git sparse-checkout set --no-cone '/*' '!/factory/'`. If you expect `factory/pages/` to exist in a worktree's filesystem and it doesn't, that's by design — the server resolves it via `git rev-parse --git-common-dir` to the main repo.
+
+## Factory server routing reference
+
+`factory/server.js` routes:
+
+| URL | Handler | Serves |
+|---|---|---|
+| `/` | `serveBrainstorm` | newest HTML from the transient brainstorm session dir (ephemeral) |
+| `/factory` or `/factory/` | `servePortfolio` | `portfolio.html` — persistent prototype landing page |
+| `/factory/<page>` | `serveFactory(page)` | `factory.html` — per-page editor with sidebar, click-to-select, style controls |
+| `/playground` | `servePlayground` | `playground.html` |
+| `/prototype?file=...` | `servePrototype` | raw prototype HTML, used by iframes |
+| `/api/*` | various | slots, write, compare, style-profile, scan, etc. |
+
+**Common gotcha:** `/factory` alone does NOT serve `factory.html` — it serves `portfolio.html` (the landing page). To reach the editor with the sidebar you need `/factory/<page>`.


### PR DESCRIPTION
## Summary

Small follow-up to v0.2.9.4. Captures two things that came out of the release conversation:

1. **New `docs/maintainer-notes.md`** — first home for maintainer-facing conventions that don't belong in README or CHANGELOG. Seeded with:
   - **Release tagging convention** — starting v0.2.9.4, release tags are annotated with a description (a style break from v0.2.4-v0.2.9.3 which were all lightweight). Future releases should match.
   - **Landmines** — `companion.config.js` stays literal despite the companion→factory rename; root `factory/` is tracked but sparse-excluded in worktrees.
   - **Factory server routing table** — reference for which URL serves which file, with the common `/factory` vs `/factory/<page>` gotcha called out.

2. **README fix** — the "Factory Server" section had the routes wrong. `/` doesn't serve the portfolio (it serves the ephemeral brainstorm preview), and `/factory` doesn't serve the editor (it serves the portfolio). The editor is at `/factory/<page>`. All three are now documented correctly.

## Why

The v0.2.9.4 tag was initially pushed lightweight, then replaced with an annotated version mid-session. The convention decision was worth capturing so it doesn't get lost. Also flagged a real doc bug in the README while we were in the neighborhood.

## Test plan

- [x] `docs/maintainer-notes.md` reads cleanly
- [x] README route table matches the actual `factory/server.js` routing code (verified against `server.js:720-777`)
- [ ] Merge once reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)