### PR TITLE
feat: add /ctx-factory skill

### DIFF
--- a/plugins/ctx/skills/ctx-factory/SKILL.md
+++ b/plugins/ctx/skills/ctx-factory/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: ctx-factory
+description: >
+  Open the brainstorm factory design viewer to browse prototype pages.
+  Use when the user says "factory", "open factory", "show designs",
+  "view designs", "see my designs", "open the factory", or invokes /ctx-factory.
+  This is a view-only launcher — it does NOT start a brainstorm session.
+user-invocable: true
+---
+
+# /ctx-factory — Open Design Viewer
+
+Launch the factory design viewer so the user can browse their prototype pages.
+
+## Steps
+
+1. Check if port 52341 is already listening:
+   ```bash
+   lsof -i :52341 -sTCP:LISTEN -t
+   ```
+
+2. **If not listening**, start the factory server:
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/skills/ctx-brainstorm/factory/start.sh --project-dir "$(pwd)"
+   ```
+   Wait for the JSON output confirming `server-started` before proceeding.
+
+3. Open the factory in the browser:
+   ```bash
+   open http://localhost:52341/factory
+   ```
+
+4. Tell the user: "Factory is open at http://localhost:52341/factory"
+
+No confirmation needed — just do it.


### PR DESCRIPTION
## Summary
- Adds /ctx-factory — standalone launcher for the brainstorm factory design viewer
- Checks port 52341, starts server if needed, opens browser
- Decouples viewing designs from starting a full brainstorm session

## Test plan
- [ ] Run /ctx-factory with server not running — should start server + open browser
- [ ] Run /ctx-factory with server already running — should just open browser
- [ ] Verify factory page loads at http://localhost:52341/factory