### PR TITLE
feat: ctx-park distill + ctx-docs skill

### DIFF
--- a/plugins/ctx/skills/ctx-docs/SKILL.md
+++ b/plugins/ctx/skills/ctx-docs/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ctx-docs
+description: >
+  Aggregate completed work into human-readable epic documentation.
+  Use when an epic or batch of issues is complete and you want a documentation
+  package. Triggers: "document this epic", "generate docs", "ctx-docs",
+  or after a batch of issues is shipped.
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep, Write
+---
+
+# /ctx-docs — Epic Documentation Aggregation
+
+Synthesize completed work into structured, human-readable docs. Pulls from Linear, specs, plans, git history, and distilled memories.
+
+---
+
+## 1. Parse arguments
+
+Two entry points:
+
+- **Epic mode:** `/ctx-docs <epic-name>` — queries Linear for the epic/project's issues
+- **Issue mode:** `/ctx-docs <epic-name> CTX-33 CTX-28 CTX-16` — user provides issue IDs directly
+
+`<epic-name>` is always required — becomes the directory name and index title.
+
+If no issue IDs provided, use the Linear MCP (`mcp__plugin_linear_linear__list_issues`) to find issues belonging to the named epic/project. If Linear is unavailable or returns nothing, ask the user for issue IDs.
+
+---
+
+## 2. Resolve issues
+
+For each issue ID:
+1. Fetch metadata from Linear via `mcp__plugin_linear_linear__get_issue` (title, description, status, labels)
+2. If Linear unavailable, proceed with issue ID only — artifact discovery still works
+
+---
+
+## 3. Gather artifacts
+
+For each issue, scan these locations:
+
+| Artifact | Location | Match strategy |
+|----------|----------|---------------|
+| Spec | `docs/specs/*.md` | Grep for issue ID in filename or content |
+| Plan | `~/.claude/plugins/marketplaces/ctx-plugin/plans/*.md` | Grep for issue ID in content |
+| Park smart context | `docs/ctx/park.md` or git history | Branch name or issue ID reference |
+| Git history | `git log --all --oneline --grep="{issue-id}"` | Commit messages |
+| Linear metadata | From step 2 | Already fetched |
+| Distilled memories | `~/.claude/projects/<project-hash>/memory/*.md` | Grep for issue ID in content or description |
+
+Not every issue will have every artifact. Work with what exists — skip missing artifacts gracefully.
+
+---
+
+## 4. Generate docs
+
+Create `docs/ctx/<epic-name>/` with:
+
+### `index.md`
+
+````markdown
+# <Epic Name>
+
+**Generated:** {timestamp}
+**Issues:** {N} completed
+**Branches:** {list}
+
+## Summary
+
+{2-3 paragraph narrative synthesized from specs and plans}
+
+## Issues
+
+| ID | Title | Complexity | Status | Branch |
+|----|-------|-----------|--------|--------|
+| ... | ... | ... | ... | ... |
+
+## Key Decisions
+
+{Aggregated from park smart context and spec "Why this approach" sections — only non-obvious decisions}
+
+## Learnings
+
+{Aggregated from distilled memories related to these issues}
+````
+
+### Per-issue docs (`<issue-id>.md`)
+
+````markdown
+# <issue-id> — {title}
+
+**Status:** {from Linear or git}
+**Branch:** {from git}
+**Spec:** {relative path to spec file, if found}
+**Plan:** {relative path to plan file, if found}
+
+## Design
+
+{From spec — problem, chosen approach, tradeoffs}
+
+## Implementation
+
+{From plan — what was built, key files touched}
+
+## Outcome
+
+{From git log — commits. From park — what actually happened}
+
+## Learnings
+
+{From park smart context + distilled memories}
+````
+
+If a section has no data (e.g., no park file found), omit that section rather than writing "N/A".
+
+---
+
+## 5. Commit
+
+```bash
+git add docs/ctx/<epic-name>/
+git commit -m "docs: <epic-name> epic documentation"
+```

--- a/plugins/ctx/skills/ctx-park/SKILL.md
+++ b/plugins/ctx/skills/ctx-park/SKILL.md
@@ -59,16 +59,66 @@ Write to the `handoff_path` from scan output (`docs/ctx/park.md`):
 {Ordered — what the next agent should do first.}
 ```
 
-## 4. Skill audit (judgment)
+## 4. Distill learnings (judgment)
+
+Review the session for non-obvious learnings. Apply the filter: **"Would a future agent make the wrong decision without this knowledge?"**
+
+**Capture:**
+- Assumptions that turned out wrong and why
+- Patterns that worked unexpectedly well
+- Constraints discovered during implementation (not in specs/docs)
+- Corrections the user made to agent behavior
+
+**Skip:**
+- Anything derivable from reading the code or git log
+- Solutions already in committed code
+- Obvious patterns the next agent would figure out from context
+- Verbose explanations (1-2 sentences per learning max)
+
+If nothing meets the filter, output `Distill: clean` and move to step 5.
+
+### 4b. Route to memory
+
+For each learning, write a memory file to `~/.claude/projects/<project-hash>/memory/`:
+
+```markdown
+---
+name: {learning title}
+description: {one-line — specific enough for future relevance matching}
+type: feedback
+---
+
+{The learning. 1-2 sentences.}
+
+**Why:** {What happened that surfaced this.}
+**How to apply:** {When this matters in future sessions.}
+```
+
+Derive `<project-hash>` from `PROJECT_ROOT` using `echo "$PROJECT_ROOT" | tr '/' '-'`.
+
+Update `MEMORY.md` index with a pointer to the new file. If `MEMORY.md` doesn't exist yet (first distill for this project), create it.
+
+### 4c. Gotcha promotion (prompt-based, on recurrence)
+
+Before writing a new memory, scan existing memories **in the current project only** for similar themes. Compare the new learning against existing memories and ask:
+
+> "Does this new learning match a pattern already captured in an existing memory? If yes, which one — and has this now occurred enough times (2+) to be promoted to a gotcha in the relevant skill file?"
+
+- **No match:** Write as new memory. Done.
+- **Match found, first recurrence:** Update the existing memory to note the second occurrence. Don't promote yet.
+- **Match found, 2+ occurrences:** Promote to gotcha — append to the relevant skill's `## Gotchas` section following the existing format (bolded title + explanation). Delete or archive the staging memory.
+
+## 5. Skill audit (judgment)
 
 If `---skill-log---` was not `none`: assess each invocation — was it the right skill for the task scope? If wrong, append a gotcha to that skill's `## Gotchas` section.
 
-## 5. Confirm
+## 6. Confirm
 
 ```
 Context parked to docs/ctx/park.md
 Artifacts linked: {N} files
 Smart context: {N} items
+Distill: {N} memories written | {N} gotchas promoted | clean
 Skill audit: {N} gotchas added | clean
 Ready to close session.
 ```


### PR DESCRIPTION
## Summary

- **ctx-park distill step:** New Step 4 captures non-obvious session learnings into memory files with recurrence-based gotcha promotion (memory → 2nd occurrence update → 3rd promotes to skill gotcha)
- **ctx-docs skill:** New `/ctx-docs` skill that aggregates specs, plans, parks, git history, Linear metadata, and distilled memories into structured epic documentation (`index.md` + per-issue docs)

## Test plan

- [ ] Run `/ctx-park` on a session with learnings — verify distill step triggers and writes memory files
- [ ] Run `/ctx-park` on a clean session — verify `Distill: clean` output
- [ ] Run `/ctx-docs <epic-name> CTX-33 CTX-28` (issue mode) — verify docs generated at `docs/ctx/<epic-name>/`
- [ ] Run `/ctx-docs <epic-name>` (epic mode with Linear) — verify Linear query fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)