### PR TITLE
refactor: rename /prototype → /page + drop legacy prototypes/ fallback

### DIFF
--- a/plugins/ctx/skills/ctx-brainstorm/factory/cli/preview-device.sh
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/cli/preview-device.sh
@@ -53,7 +53,7 @@ echo "Device: $DEVICE" >&2
 if [[ -n "$FULL_URL" ]]; then
   URL="$FULL_URL"
 elif [[ -n "$PROTO_FILE" ]]; then
-  URL="http://localhost:${PORT}/prototype?file=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${PROTO_FILE}'))")"
+  URL="http://localhost:${PORT}/page?file=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${PROTO_FILE}'))")"
 elif [[ -n "$URL_PATH" ]]; then
   URL="http://localhost:${PORT}${URL_PATH}"
 else

--- a/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
@@ -672,7 +672,7 @@ function setPreview(filePath) {
   if (placeholder) placeholder.style.display = 'none';
 
   var existing = container.querySelector('.preview-iframe');
-  var url = '/prototype?file=' + encodeURIComponent(filePath);
+  var url = '/page?file=' + encodeURIComponent(filePath);
   if (existing) {
     existing.src = url;
   } else {
@@ -1304,7 +1304,7 @@ function enterCompareMode(items) {
     if (item.file) {
       var iframe = document.createElement('iframe');
       iframe.className = 'compare-iframe';
-      iframe.src = '/prototype?file=' + encodeURIComponent(item.file);
+      iframe.src = '/page?file=' + encodeURIComponent(item.file);
       col.appendChild(iframe);
     } else {
       var notFound = document.createElement('div');
@@ -1334,7 +1334,7 @@ function exitCompareMode() {
     savedChildren = null;
     var iframe = document.querySelector('.preview-iframe');
     if (iframe && activeFile) {
-      iframe.src = '/prototype?file=' + encodeURIComponent(activeFile);
+      iframe.src = '/page?file=' + encodeURIComponent(activeFile);
     }
   }
 }

--- a/plugins/ctx/skills/ctx-brainstorm/factory/playground.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/playground.html
@@ -392,7 +392,7 @@ const previewContainer = document.getElementById('preview-container');
 if (protoFile) {
   const iframe = document.createElement('iframe');
   iframe.className = 'preview-iframe';
-  iframe.src = '/prototype?file=' + encodeURIComponent(protoFile);
+  iframe.src = '/page?file=' + encodeURIComponent(protoFile);
   previewContainer.appendChild(iframe);
 } else {
   const placeholder = document.createElement('div');

--- a/plugins/ctx/skills/ctx-brainstorm/factory/portfolio.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/portfolio.html
@@ -173,7 +173,7 @@ function renderCards(pages) {
     thumb.className = 'card-thumb';
     if (p.latestFile) {
       var iframe = document.createElement('iframe');
-      iframe.src = '/prototype?file=' + encodeURIComponent(p.latestFile);
+      iframe.src = '/page?file=' + encodeURIComponent(p.latestFile);
       iframe.setAttribute('loading', 'lazy');
       iframe.setAttribute('tabindex', '-1');
       thumb.appendChild(iframe);

--- a/plugins/ctx/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/server.js
@@ -477,8 +477,8 @@ function serveBrainstorm(res) {
 
 function scanSlots() {
   if (!pagesRoot) return [];
-  const prototypesDir = path.join(pagesRoot, "factory/pages");
-  if (!fs.existsSync(prototypesDir)) return [];
+  const factoryPagesDir = path.join(pagesRoot, "factory/pages");
+  if (!fs.existsSync(factoryPagesDir)) return [];
 
   const slots = new Map();
 
@@ -512,7 +512,7 @@ function scanSlots() {
     }
   }
 
-  scan(prototypesDir, "");
+  scan(factoryPagesDir, "");
 
   // Sort iterations within each slot by version number
   const result = [];

--- a/plugins/ctx/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/server.js
@@ -574,18 +574,6 @@ async function handleDiscover(req, res) {
     } catch (err) {
       jsonResponse(res, 500, { error: err.message });
     }
-  } else if (projectDir) {
-    const prototypesDir = path.join(projectDir, "prototypes");
-    if (!fs.existsSync(prototypesDir)) {
-      jsonResponse(res, 200, []);
-      return;
-    }
-    const files = fs.readdirSync(prototypesDir).filter(f => f.endsWith(".html"));
-    jsonResponse(res, 200, files.map(f => ({
-      id: f.replace(/\.html$/, ""),
-      label: f.replace(/\.html$/, ""),
-      path: f,
-    })));
   } else {
     jsonResponse(res, 200, []);
   }

--- a/plugins/ctx/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/server.js
@@ -420,7 +420,7 @@ function serveFactory(res, targetPage) {
   res.end(content);
 }
 
-function servePrototype(res, filePath) {
+function servePage(res, filePath) {
   if (!pagesRoot) {
     res.writeHead(400, { "Content-Type": "text/plain" });
     res.end("No --project-dir configured");
@@ -434,7 +434,7 @@ function servePrototype(res, filePath) {
   }
   if (!fs.existsSync(resolved)) {
     res.writeHead(404, { "Content-Type": "text/plain" });
-    res.end(`Prototype not found: ${filePath}`);
+    res.end(`Page not found: ${filePath}`);
     return;
   }
   let content = fs.readFileSync(resolved, "utf8");
@@ -713,8 +713,8 @@ const server = http.createServer((req, res) => {
     handleStatus(req, res);
   } else if (parsed.pathname === "/playground") {
     servePlayground(res);
-  } else if (parsed.pathname === "/prototype" && parsed.searchParams.get("file")) {
-    servePrototype(res, parsed.searchParams.get("file"));
+  } else if (parsed.pathname === "/page" && parsed.searchParams.get("file")) {
+    servePage(res, parsed.searchParams.get("file"));
   } else if (parsed.pathname === "/api/slots") {
     jsonResponse(res, 200, scanSlots());
   } else if (parsed.pathname === "/api/write" && req.method === "POST") {


### PR DESCRIPTION
## Summary
- Remove dead `else if (projectDir)` branch in `handleDiscover` that fell back to reading HTML from `projectDir/prototypes/`. Modern projects use `config.discover()` which reads from `factory/pages/`, so the fallback was unreachable in practice.
- Rename `/prototype` route → `/page` and `servePrototype` → `servePage` in `server.js`, plus all 5 frontend callers (`factory.html` ×3, `portfolio.html`, `playground.html`, `cli/preview-device.sh`). The route serves from `factory/pages/`, so "page" matches the source of truth.
- Rename `prototypesDir` → `factoryPagesDir` in `scanSlots()`. The var actually held `pagesRoot/factory/pages` — the old name was a misleading holdover.

## Out of scope (intentional)
- Comments referring to "prototype styles" / "inside prototypes" — these use "prototype" as a design concept, not a path identifier.
- UI strings ("Loading prototypes...", "No prototype files found...") and `references/factory-frontend.md` — same reason: conceptual noun, not technical identifier.
- `playground.html`'s `?prototype=` query parameter — it's an input *to* playground.html, not a caller of the `/prototype` route.

## Test plan
- [ ] Factory UI loads and previews pages from `factory/pages/`
- [ ] Portfolio thumbnails render
- [ ] Playground iframe loads when visited with `?prototype=path/file.html`
- [ ] `preview-device.sh --port <p> --file <f>` opens the simulator and loads the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)