### PR TITLE
feat(factory): group prototype pages and scope version navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ docs/ctx/
 
 # Session-local specs (design docs from brainstorm sessions)
 docs/specs/
+
+# Factory runtime state
+.ctx-brainstorm/**/.server-info
+.ctx-brainstorm/**/.server-stopped
+
+.server-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md
+
+Guidance for agents working on `ctx-plugin` itself.
+
+## Purpose
+
+This repository contains the source for the same workflow toolkit in two runtimes:
+
+- `plugins/ctx` — Claude plugin
+- `plugins/ctx-codex` — Codex port
+
+Top-level docs and release notes describe the product as a whole. Most maintainer work is either:
+
+- mirrored across both plugin trees, or
+- intentionally runtime-specific and limited to one tree
+
+## Repo Map
+
+- `README.md` — user-facing product overview and workflow description
+- `CHANGELOG.md` — release history; update for user-visible changes
+- `docs/maintainer-notes.md` — maintainer landmines and release-tagging rules
+- `plugins/ctx/.claude-plugin/plugin.json` — Claude plugin manifest
+- `plugins/ctx-codex/.codex-plugin/plugin.json` — Codex plugin manifest
+- `plugins/ctx/skills/` — Claude skill prompts and references
+- `plugins/ctx-codex/skills/` — Codex skill prompts and references
+- `plugins/ctx/scripts/` — Claude-side shell helpers
+- `plugins/ctx-codex/scripts/` — Codex-side shell helpers
+- `plugins/ctx/hooks/` — Claude hook wiring and shell hooks
+- `plugins/ctx/agents/` — Claude subagent prompts
+
+## Change Strategy
+
+- Treat `plugins/ctx` and `plugins/ctx-codex` as sibling products with intentionally similar structure.
+- If a change affects workflow behavior, shell script contracts, prompt logic, reference docs, or naming conventions, check whether the equivalent file exists in the other tree and update it too unless the behavior is runtime-specific.
+- Keep mirrored files aligned in layout and semantics. Avoid letting one tree drift accidentally.
+- Prefer editing the existing mirrored script or skill instead of creating a one-off variant with a different contract.
+
+## Script Conventions
+
+- Shell helpers are expected to take args in, print progress to stderr, and return structured `key=value` output on stdout.
+- Preserve script names and flag shapes unless the user explicitly wants a breaking change.
+- When changing a script in one runtime, inspect the counterpart in the other runtime before finishing.
+
+## Release Discipline
+
+- For user-visible changes, update `CHANGELOG.md` in the same change.
+- Bump the manifest version for the runtime you changed:
+  - `plugins/ctx/.claude-plugin/plugin.json`
+  - `plugins/ctx-codex/.codex-plugin/plugin.json`
+- Follow `docs/maintainer-notes.md` for release tagging. Starting with `v0.2.9.4`, tags are annotated, not lightweight.
+
+## Validation
+
+- For script changes, run the matching integration harness:
+  - `plugins/ctx/scripts/test-scripts.sh`
+  - `plugins/ctx-codex/scripts/test-scripts.sh`
+- For skill or doc changes, verify referenced relative paths still exist and still match the repo layout.
+- For mirrored changes, sanity-check both plugin trees before concluding the work is done.
+
+## Known Landmines
+
+- The `companion` to `factory` rename is incomplete by design. Preserve literal `companion.config.js` references where existing source still depends on that name.
+- Worktrees created by the plugin intentionally sparse-exclude the repo-root `factory/` directory. Do not assume `factory/pages/` exists inside every generated worktree.
+- Factory routing is easy to misread:
+  - `/factory` serves the portfolio landing page
+  - `/factory/<page>` serves the editor UI
+
+## Scope Hygiene
+
+- Do not treat `.claude/skill-invocations.log` or similar runtime logs as durable product source.
+- Avoid incidental repo-wide rewrites unless they are required for the task.
+- If a docs statement and the code disagree, trust the code only after checking `docs/maintainer-notes.md` and `CHANGELOG.md` for intentional exceptions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.9.6 (2026-04-22)
+
+- **Factory grouped navigation (CTX-46)** — factory prototypes can now be stored under `factory/pages/<group>/<page>/`, `scanSlots()` exposes group metadata, `/api/write` accepts a `group` field, the editor sidebar renders collapsible group sections, the top-bar version dropdown is scoped to the active page, and left/right arrows switch pages independently of version selection. Deep links and portfolio cards now support grouped page paths.
+
 ## 0.2.9.4 (2026-04-08)
 
 - **Factory rename — skill source** — completes the rename started in v0.2.9.2. `plugins/ctx/skills/ctx-brainstorm/companion/` → `factory/`, plus all path references, reference docs (`companion-guide.md` → `factory-guide.md`, `companion-frontend.md` → `factory-frontend.md`), and UX/feature language in the `ctx-brainstorm` and `ctx-brainstorm-ss` skill docs. Plugin interface file `companion.config.js` stays unchanged.

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ bash plugins/ctx/skills/ctx-brainstorm/factory/start.sh \
 ```
 
 - **Portfolio** at `/factory` — all prototype pages
-- **Editor** at `/factory/<page>` — visual brainstorming with click-to-select, style controls, version pills
+- **Editor** at `/factory/<group>/<page>` — visual brainstorming with click-to-select, grouped navigation, style controls, version pills
 - **Preview** at `/` — ephemeral view of current brainstorm output
 - **API** at `/api/write`, `/api/page-status`, `/api/slots`, `/api/style-profile`
 
-Pages stored in `<project-dir>/factory/pages/<page>/.events`. Tracked in git for iteration history. Excluded from dev worktrees via sparse-checkout.
+Pages stored in `<project-dir>/factory/pages/<group>/<page>/.events`. Tracked in git for iteration history. Excluded from dev worktrees via sparse-checkout.
 
 ## Recommended Settings
 

--- a/docs/maintainer-notes.md
+++ b/docs/maintainer-notes.md
@@ -43,9 +43,9 @@ git push origin vX.Y.Z
 |---|---|---|
 | `/` | `serveBrainstorm` | newest HTML from the transient brainstorm session dir (ephemeral) |
 | `/factory` or `/factory/` | `servePortfolio` | `portfolio.html` — persistent prototype landing page |
-| `/factory/<page>` | `serveFactory(page)` | `factory.html` — per-page editor with sidebar, click-to-select, style controls |
+| `/factory/<group>/<page>` | `serveFactory(page)` | `factory.html` — per-page editor with grouped sidebar, click-to-select, style controls |
 | `/playground` | `servePlayground` | `playground.html` |
 | `/prototype?file=...` | `servePrototype` | raw prototype HTML, used by iframes |
 | `/api/*` | various | slots, write, compare, style-profile, scan, etc. |
 
-**Common gotcha:** `/factory` alone does NOT serve `factory.html` — it serves `portfolio.html` (the landing page). To reach the editor with the sidebar you need `/factory/<page>`.
+**Common gotcha:** `/factory` alone does NOT serve `factory.html` — it serves `portfolio.html` (the landing page). To reach the editor with the sidebar you need `/factory/<group>/<page>`.

--- a/factory/style-profile.json
+++ b/factory/style-profile.json
@@ -1,0 +1,11 @@
+{
+  "meta": {
+    "scannedAt": "2026-04-22T15:32:25.892Z",
+    "sources": []
+  },
+  "colors": {},
+  "typography": {},
+  "spacing": {},
+  "components": {},
+  "custom": {}
+}

--- a/plugins/ctx-codex/.codex-plugin/plugin.json
+++ b/plugins/ctx-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ctx-codex",
-  "version": "0.2.9.5",
+  "version": "0.2.9.6",
   "description": "Context economy workflow toolkit for Codex: brainstorm, plan, execute, verify, ship, and manage worktree handoffs with minimal token spend.",
   "author": {
     "name": "Garo Nazarian",

--- a/plugins/ctx-codex/skills/ctx-brainstorm/SKILL.md
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/SKILL.md
@@ -26,7 +26,7 @@ before the spec is written and approved.
 3b. **Factory mode** — when the factory is running at `/factory`:
     - **Read `./factory/references/factory-frontend.md` before generating any prototype.**
     - Read `factory/style-profile.json` for design tokens when generating prototypes (just-in-time — don't preload)
-    - **NEVER use Edit/Write to create prototypes directly.** Always use `POST http://localhost:<port>/api/write` with `{ "page": "<name>", "content": "<html>" }` — this auto-versions, reloads the factory, and respects the cross-repo guard. Direct file writes to `factory/pages/` in another repo will be blocked by `worktree-guard.sh`.
+    - **NEVER use Edit/Write to create prototypes directly.** Always use `POST http://localhost:<port>/api/write` with `{ "group": "<app-page>", "page": "<prototype-name>", "content": "<html>" }` — ask or infer the target app page first so new prototypes land under the right group. This auto-versions, reloads the factory, and respects the cross-repo guard. Direct file writes to `factory/pages/` in another repo will be blocked by `worktree-guard.sh`.
     - Read `<screen-dir>/.events` for `option-select` (user clicked a choice) and `style` (user changed controls) events
     - Use `data-option` on comparison pages — see "Prototype structure" in factory-guide.md
 4. **Ask questions** — one at a time, prefer multiple choice, understand purpose/constraints/success criteria
@@ -138,7 +138,7 @@ Present this handoff when the user approves a factory prototype:
 
 > Prototype `<page>-v<N>` approved.
 > - **Target repo:** `<project-dir from --project-dir>`
-> - **Prototype:** `factory/pages/<page>/<page>-v<N>.html`
+> - **Prototype:** `factory/pages/<group>/<page>/<page>-v<N>.html`
 > - **Replaces:** `<component path from discussion>`
 >
 > Next: `ctx-worktree` in the target project, then `ctx-plan` to port the prototype to React + Tailwind.

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
@@ -55,6 +55,23 @@
     min-width: 180px;
   }
   .proto-select:focus { outline: none; border-color: #818cf8; }
+  .page-nav {
+    display: flex;
+    gap: 0.3rem;
+  }
+  .page-nav-btn {
+    background: #0f172a;
+    color: #94a3b8;
+    border: 1px solid #334155;
+    border-radius: 4px;
+    width: 28px;
+    height: 28px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: all 0.12s;
+  }
+  .page-nav-btn:hover:not(:disabled) { border-color: #818cf8; color: #c7d2fe; }
+  .page-nav-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
   /* Viewport pills */
   .viewport-pills {
@@ -158,6 +175,45 @@
   }
 
   /* Pages section */
+  .page-group {
+    margin-bottom: 0.55rem;
+  }
+  .page-group-header {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.28rem 0.1rem 0.38rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+  .page-group-title {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #64748b;
+  }
+  .page-group-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+  }
+  .page-group-count {
+    font-size: 0.6rem;
+    color: #475569;
+  }
+  .page-group-chevron {
+    font-size: 0.72rem;
+    color: #64748b;
+  }
+  .page-group-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 0.12rem;
+  }
   .page-row {
     display: flex;
     align-items: center;
@@ -503,6 +559,10 @@
     <button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()" title="Toggle sidebar" aria-label="Toggle sidebar">&#9776;</button>
     <span class="top-bar-title">Tinker Factory</span>
     <span class="top-bar-context" id="top-bar-context"></span>
+    <div class="page-nav">
+      <button class="page-nav-btn" id="page-prev" onclick="goToAdjacentPage(-1)" title="Previous page" aria-label="Previous page">&larr;</button>
+      <button class="page-nav-btn" id="page-next" onclick="goToAdjacentPage(1)" title="Next page" aria-label="Next page">&rarr;</button>
+    </div>
     <select class="proto-select" id="proto-select" onchange="selectProtoFromDropdown(this.value)">
       <option value="">Loading slots...</option>
     </select>
@@ -578,6 +638,8 @@ var allSlots = [];
 var compareMode = false;
 var compareItems = [];
 var currentViewport = 'desktop';
+var expandedGroups = {};
+var previewFileBase = '/prototype?file=';
 
 // --- Sidebar collapse ---
 // Default collapsed; user preference persisted in localStorage.
@@ -612,6 +674,81 @@ function makeText(tag, className, text) {
   return el;
 }
 
+function buildPreviewUrl(filePath) {
+  return previewFileBase + encodeURIComponent(filePath);
+}
+
+function findSlot(slotName) {
+  for (var i = 0; i < allSlots.length; i++) {
+    if (allSlots[i].slot === slotName) return allSlots[i];
+  }
+  return null;
+}
+
+function getGroupName(slotData) {
+  return slotData && slotData.group ? slotData.group : 'Ungrouped';
+}
+
+function getPageLabel(slotData) {
+  return slotData ? (slotData.page || slotData.slot) : '';
+}
+
+function getPageContextLabel(slotData) {
+  if (!slotData) return '';
+  return getGroupName(slotData) === 'Ungrouped'
+    ? getPageLabel(slotData)
+    : getGroupName(slotData) + ' / ' + getPageLabel(slotData);
+}
+
+function updatePageNavButtons() {
+  var prev = document.getElementById('page-prev');
+  var next = document.getElementById('page-next');
+  var index = -1;
+
+  for (var i = 0; i < allSlots.length; i++) {
+    if (allSlots[i].slot === activePage) {
+      index = i;
+      break;
+    }
+  }
+
+  prev.disabled = index <= 0;
+  next.disabled = index === -1 || index >= allSlots.length - 1;
+}
+
+function goToAdjacentPage(direction) {
+  if (!activePage) return;
+  for (var i = 0; i < allSlots.length; i++) {
+    if (allSlots[i].slot === activePage) {
+      var target = allSlots[i + direction];
+      if (target) activatePage(target.slot, true);
+      return;
+    }
+  }
+}
+
+function renderProtoSelect() {
+  var protoSelect = document.getElementById('proto-select');
+  clearChildren(protoSelect);
+
+  var slotData = findSlot(activePage);
+  if (!slotData) {
+    var emptyOpt = document.createElement('option');
+    emptyOpt.value = '';
+    emptyOpt.textContent = 'Select a page';
+    protoSelect.appendChild(emptyOpt);
+    return;
+  }
+
+  slotData.iterations.forEach(function(iter) {
+    var opt = document.createElement('option');
+    opt.value = iter.file;
+    opt.textContent = iter.label;
+    if (iter.file === activeFile) opt.selected = true;
+    protoSelect.appendChild(opt);
+  });
+}
+
 // --- Viewport ---
 function setViewport(v) {
   currentViewport = v;
@@ -639,10 +776,11 @@ function setViewport(v) {
 // --- Top bar context ---
 function updateTopBarContext() {
   var ctx = document.getElementById('top-bar-context');
-  if (activePage && activeVersion) {
-    ctx.textContent = activePage + ' / ' + activeVersion;
-  } else if (activePage) {
-    ctx.textContent = activePage;
+  var slotData = findSlot(activePage);
+  if (slotData && activeVersion) {
+    ctx.textContent = getPageContextLabel(slotData) + ' / ' + activeVersion;
+  } else if (slotData) {
+    ctx.textContent = getPageContextLabel(slotData);
   } else {
     ctx.textContent = '';
   }
@@ -672,7 +810,7 @@ function setPreview(filePath) {
   if (placeholder) placeholder.style.display = 'none';
 
   var existing = container.querySelector('.preview-iframe');
-  var url = '/prototype?file=' + encodeURIComponent(filePath);
+  var url = buildPreviewUrl(filePath);
   if (existing) {
     existing.src = url;
   } else {
@@ -703,48 +841,120 @@ function setPreview(filePath) {
 
 function selectProtoFromDropdown(filePath) {
   if (!filePath) return;
-  for (var s = 0; s < allSlots.length; s++) {
-    var slotData = allSlots[s];
-    for (var it = 0; it < slotData.iterations.length; it++) {
-      var iter = slotData.iterations[it];
-      if (iter.file === filePath) {
-        activatePage(slotData.slot, false);
-        activeVersion = iter.label;
-        setPreview(filePath);
-        sendEvent({ type: 'select', slot: slotData.slot, iteration: iter.slug.split('--')[1] || iter.slug });
-        return;
-      }
+  var slotData = findSlot(activePage);
+  if (!slotData) return;
+  for (var it = 0; it < slotData.iterations.length; it++) {
+    var iter = slotData.iterations[it];
+    if (iter.file === filePath) {
+      activeVersion = iter.label;
+      setPreview(filePath);
+      sendEvent({ type: 'select', slot: slotData.slot, iteration: iter.slug.split('--')[1] || iter.slug });
+      return;
     }
   }
-  setPreview(filePath);
+}
+
+function toggleGroup(groupName) {
+  expandedGroups[groupName] = !expandedGroups[groupName];
+  renderPagesList();
+}
+
+function renderPagesList() {
+  var pagesList = document.getElementById('pages-list');
+  clearChildren(pagesList);
+
+  if (!allSlots || allSlots.length === 0) {
+    pagesList.appendChild(makeText('span', 'empty-hint', 'No prototype pages found'));
+    return;
+  }
+
+  var grouped = {};
+  var order = [];
+  allSlots.forEach(function(slotData) {
+    var groupName = getGroupName(slotData);
+    if (!grouped[groupName]) {
+      grouped[groupName] = [];
+      order.push(groupName);
+      if (expandedGroups[groupName] == null) expandedGroups[groupName] = true;
+    }
+    grouped[groupName].push(slotData);
+  });
+
+  order.forEach(function(groupName) {
+    var group = document.createElement('div');
+    group.className = 'page-group';
+
+    var header = document.createElement('button');
+    header.className = 'page-group-header';
+    header.type = 'button';
+    header.onclick = function() { toggleGroup(groupName); };
+
+    header.appendChild(makeText('span', 'page-group-title', groupName));
+
+    var meta = document.createElement('span');
+    meta.className = 'page-group-meta';
+    meta.appendChild(makeText('span', 'page-group-count', grouped[groupName].length + ''));
+    meta.appendChild(makeText('span', 'page-group-chevron', expandedGroups[groupName] ? '\u25be' : '\u25b8'));
+    header.appendChild(meta);
+    group.appendChild(header);
+
+    var rows = document.createElement('div');
+    rows.className = 'page-group-rows';
+    rows.style.display = expandedGroups[groupName] ? '' : 'none';
+
+    grouped[groupName].forEach(function(slotData) {
+      var row = document.createElement('div');
+      row.className = 'page-row' + (slotData.slot === activePage ? ' active' : '');
+      row.dataset.slot = slotData.slot;
+
+      row.appendChild(makeText('span', 'page-row-name', getPageLabel(slotData)));
+      row.appendChild(makeText('span', 'page-row-count', slotData.iterations.length + ''));
+      row.onclick = function() { activatePage(slotData.slot, true); };
+
+      rows.appendChild(row);
+    });
+
+    group.appendChild(rows);
+    pagesList.appendChild(group);
+  });
+}
+
+function selectInitialPage() {
+  var target = window.__factoryPage;
+  if (target && findSlot(target)) {
+    activatePage(target, true);
+    return;
+  }
+  if (allSlots.length > 0) {
+    activatePage(allSlots[0].slot, true);
+  } else {
+    updatePageNavButtons();
+  }
 }
 
 // --- Pages ---
-function activatePage(slotName, autoSelectFirst) {
-  activePage = slotName;
+function activatePage(slotName, autoSelectLatest) {
+  var slotData = findSlot(slotName);
+  if (!slotData) return;
 
-  var rows = document.querySelectorAll('.page-row');
-  for (var i = 0; i < rows.length; i++) {
-    rows[i].classList.toggle('active', rows[i].dataset.slot === slotName);
-  }
+  activePage = slotName;
+  renderPagesList();
 
   var versionsSection = document.getElementById('versions-section');
   versionsSection.style.display = '';
   renderVersionPills(slotName);
+  renderProtoSelect();
+  updatePageNavButtons();
 
-  if (autoSelectFirst) {
-    var slotData = null;
-    for (var s = 0; s < allSlots.length; s++) {
-      if (allSlots[s].slot === slotName) { slotData = allSlots[s]; break; }
-    }
-    if (slotData && slotData.iterations.length > 0) {
-      var last = slotData.iterations[slotData.iterations.length - 1];
-      activeVersion = last.label;
-      setPreview(last.file);
-      sendEvent({ type: 'select', slot: slotName, iteration: last.slug.split('--')[1] || last.slug });
-    }
+  if (autoSelectLatest && slotData.iterations.length > 0) {
+    var last = slotData.iterations[slotData.iterations.length - 1];
+    activeVersion = last.label;
+    setPreview(last.file);
+    sendEvent({ type: 'select', slot: slotName, iteration: last.slug.split('--')[1] || last.slug });
+    return;
   }
 
+  updateVersionPills();
   updateTopBarContext();
 }
 
@@ -752,10 +962,7 @@ function renderVersionPills(slotName) {
   var pillsEl = document.getElementById('version-pills');
   clearChildren(pillsEl);
 
-  var slotData = null;
-  for (var s = 0; s < allSlots.length; s++) {
-    if (allSlots[s].slot === slotName) { slotData = allSlots[s]; break; }
-  }
+  var slotData = findSlot(slotName);
   if (!slotData) return;
 
   slotData.iterations.forEach(function(iter) {
@@ -765,13 +972,11 @@ function renderVersionPills(slotName) {
     pill.dataset.file = iter.file;
     pill.dataset.label = iter.label;
     pill.title = iter.file;
-    (function(sn, slug, file, label) {
-      pill.onclick = function() {
-        activeVersion = label;
-        setPreview(file);
-        sendEvent({ type: 'select', slot: sn, iteration: slug.split('--')[1] || slug });
-      };
-    })(slotName, iter.slug, iter.file, iter.label);
+    pill.onclick = function() {
+      activeVersion = iter.label;
+      setPreview(iter.file);
+      sendEvent({ type: 'select', slot: slotName, iteration: iter.slug.split('--')[1] || iter.slug });
+    };
     pillsEl.appendChild(pill);
   });
 }
@@ -785,20 +990,21 @@ function updateVersionPills() {
 
 // --- Slot rendering ---
 function renderSlots(slots) {
-  allSlots = slots;
+  allSlots = slots || [];
 
-  var pagesList = document.getElementById('pages-list');
   var protoSelect = document.getElementById('proto-select');
   var versionsSection = document.getElementById('versions-section');
 
-  clearChildren(pagesList);
+  activeFile = null;
+  activePage = null;
+  activeVersion = null;
+
   clearChildren(protoSelect);
   versionsSection.style.display = 'none';
   clearChildren(document.getElementById('version-pills'));
+  renderPagesList();
 
-  if (!slots || slots.length === 0) {
-    pagesList.appendChild(makeText('span', 'empty-hint', 'No prototype pages found'));
-
+  if (!allSlots.length) {
     var noOpt = document.createElement('option');
     noOpt.value = '';
     noOpt.textContent = 'No prototypes';
@@ -809,42 +1015,12 @@ function renderSlots(slots) {
       ph.style.display = '';
       document.getElementById('preview-placeholder-msg').textContent = 'No prototype files found in factory/pages/';
     }
+    updateTopBarContext();
+    updatePageNavButtons();
     return;
   }
 
-  var blankOpt = document.createElement('option');
-  blankOpt.value = '';
-  blankOpt.textContent = 'Jump to...';
-  protoSelect.appendChild(blankOpt);
-
-  slots.forEach(function(slotData) {
-    var slotName = slotData.slot;
-    var iterations = slotData.iterations;
-
-    var row = document.createElement('div');
-    row.className = 'page-row';
-    row.dataset.slot = slotName;
-
-    row.appendChild(makeText('span', 'page-row-name', slotName));
-    row.appendChild(makeText('span', 'page-row-count', iterations.length + ''));
-
-    (function(sn) {
-      row.onclick = function() { activatePage(sn, true); };
-    })(slotName);
-
-    pagesList.appendChild(row);
-
-    iterations.forEach(function(iter) {
-      var opt = document.createElement('option');
-      opt.value = iter.file;
-      opt.textContent = slotName + ' / ' + iter.label;
-      protoSelect.appendChild(opt);
-    });
-  });
-
-  if (slots.length > 0) {
-    activatePage(slots[0].slot, true);
-  }
+  selectInitialPage();
 }
 
 // --- Load slots ---
@@ -852,15 +1028,6 @@ fetch('/api/slots')
   .then(function(r) { return r.json(); })
   .then(function(slots) {
     renderSlots(slots);
-    if (window.__factoryPage) {
-      var target = window.__factoryPage;
-      for (var s = 0; s < allSlots.length; s++) {
-        if (allSlots[s].slot === target) {
-          activatePage(target, true);
-          return;
-        }
-      }
-    }
   })
   .catch(function(err) {
     var ph = document.getElementById('preview-placeholder');
@@ -872,6 +1039,7 @@ fetch('/api/slots')
     errOpt.value = '';
     errOpt.textContent = 'Error loading';
     document.getElementById('proto-select').appendChild(errOpt);
+    updatePageNavButtons();
   });
 
 // --- Style Controls ---
@@ -1304,7 +1472,7 @@ function enterCompareMode(items) {
     if (item.file) {
       var iframe = document.createElement('iframe');
       iframe.className = 'compare-iframe';
-      iframe.src = '/prototype?file=' + encodeURIComponent(item.file);
+      iframe.src = buildPreviewUrl(item.file);
       col.appendChild(iframe);
     } else {
       var notFound = document.createElement('div');
@@ -1334,7 +1502,7 @@ function exitCompareMode() {
     savedChildren = null;
     var iframe = document.querySelector('.preview-iframe');
     if (iframe && activeFile) {
-      iframe.src = '/prototype?file=' + encodeURIComponent(activeFile);
+      iframe.src = buildPreviewUrl(activeFile);
     }
   }
 }

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/portfolio.html
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/portfolio.html
@@ -100,6 +100,11 @@
     color: #a5b4fc;
     border: 1px solid #312e81;
   }
+  .badge-group {
+    background: #172554;
+    color: #93c5fd;
+    border: 1px solid #1d4ed8;
+  }
   .badge-selected {
     background: #042f2e;
     color: #5eead4;
@@ -138,6 +143,12 @@
 </div>
 
 <script>
+function buildFactoryHref(page) {
+  return '/factory/' + page.split('/').map(function(part) {
+    return encodeURIComponent(part);
+  }).join('/');
+}
+
 function relativeTime(iso) {
   if (!iso) return '';
   var diff = Date.now() - new Date(iso).getTime();
@@ -166,7 +177,7 @@ function renderCards(pages) {
   pages.forEach(function(p) {
     var card = document.createElement('div');
     card.className = 'card';
-    card.onclick = function() { window.location.href = '/factory/' + encodeURIComponent(p.page); };
+    card.onclick = function() { window.location.href = buildFactoryHref(p.page); };
 
     // Thumbnail
     var thumb = document.createElement('div');
@@ -186,7 +197,7 @@ function renderCards(pages) {
 
     var name = document.createElement('div');
     name.className = 'card-name';
-    name.textContent = p.page;
+    name.textContent = p.name || p.page;
     body.appendChild(name);
 
     var meta = document.createElement('div');
@@ -196,6 +207,13 @@ function renderCards(pages) {
     vBadge.className = 'badge badge-versions';
     vBadge.textContent = p.versions + (p.versions === 1 ? ' version' : ' versions');
     meta.appendChild(vBadge);
+
+    if (p.group && p.group !== 'Ungrouped') {
+      var gBadge = document.createElement('span');
+      gBadge.className = 'badge badge-group';
+      gBadge.textContent = p.group;
+      meta.appendChild(gBadge);
+    }
 
     if (p.selectedOption) {
       var sBadge = document.createElement('span');

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/references/factory-frontend.md
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/references/factory-frontend.md
@@ -52,7 +52,7 @@ Apply the Apple copy formula:
 ## Phase 3 — Prototype Implementation
 
 ### Delivery
-**Always** `POST /api/write` with `{ "page": "<name>", "content": "<html>" }`. Never Edit/Write directly — the cross-repo guard blocks it and you lose auto-versioning.
+**Always** `POST /api/write` with `{ "group": "<app-page>", "page": "<name>", "content": "<html>" }`. Ask or infer the target app page before writing. Never Edit/Write directly — the cross-repo guard blocks it and you lose auto-versioning.
 
 ### Code Rules
 - **Vanilla HTML/CSS/JS only.** No build step, no frameworks, no imports.

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
@@ -420,6 +420,18 @@ function serveFactory(res, targetPage) {
   res.end(content);
 }
 
+function decodeFactoryPath(value) {
+  try {
+    return value
+      .split("/")
+      .filter(Boolean)
+      .map(segment => decodeURIComponent(segment))
+      .join("/");
+  } catch {
+    return value;
+  }
+}
+
 function servePrototype(res, filePath) {
   if (!pagesRoot) {
     res.writeHead(400, { "Content-Type": "text/plain" });
@@ -475,10 +487,35 @@ function serveBrainstorm(res) {
 
 // ========== Slot Scanner ==========
 
+const DEFAULT_FACTORY_GROUP = "Ungrouped";
+
+function describeSlotPath(relativeDir) {
+  const segments = relativeDir.split("/").filter(Boolean);
+  if (segments.length === 0) {
+    return { group: DEFAULT_FACTORY_GROUP, page: "root", slot: "root" };
+  }
+  if (segments.length === 1) {
+    return {
+      group: DEFAULT_FACTORY_GROUP,
+      page: segments[0],
+      slot: segments[0],
+    };
+  }
+  return {
+    group: segments[0],
+    page: segments.slice(1).join("/"),
+    slot: segments.join("/"),
+  };
+}
+
+function sanitizePathPart(value) {
+  return String(value || "").trim().replace(/[^a-zA-Z0-9_-]/g, "");
+}
+
 function scanSlots() {
   if (!pagesRoot) return [];
-  const prototypesDir = path.join(pagesRoot, "factory/pages");
-  if (!fs.existsSync(prototypesDir)) return [];
+  const factoryPagesDir = path.join(pagesRoot, "factory/pages");
+  if (!fs.existsSync(factoryPagesDir)) return [];
 
   const slots = new Map();
 
@@ -497,41 +534,57 @@ function scanSlots() {
       if (stat.isDirectory()) {
         scan(fullPath, prefix ? prefix + "/" + entry.name : entry.name);
       } else if (entry.name.endsWith(".html")) {
-        const slotName = prefix || "root";
         const filePath = prefix ? prefix + "/" + entry.name : entry.name;
         const baseName = entry.name.replace(/\.html$/, "");
+        const slotMeta = describeSlotPath(prefix || "");
+        const slotName = slotMeta.slot;
 
         // Parse version: name-v2 → "v2", name-v2-bold → "v2-bold", name → "v1"
         const vMatch = baseName.match(/-v(\d+.*)$/);
         const label = vMatch ? "v" + vMatch[1] : "v1";
         const slug = slotName + "--" + baseName;
 
-        if (!slots.has(slotName)) slots.set(slotName, []);
-        slots.get(slotName).push({ slug, label, file: filePath });
+        if (!slots.has(slotName)) {
+          slots.set(slotName, {
+            group: slotMeta.group,
+            page: slotMeta.page,
+            slot: slotName,
+            iterations: [],
+          });
+        }
+        slots.get(slotName).iterations.push({ slug, label, file: filePath });
       }
     }
   }
 
-  scan(prototypesDir, "");
+  scan(factoryPagesDir, "");
 
   // Sort iterations within each slot by version number
   const result = [];
-  for (const [slot, iterations] of slots) {
-    iterations.sort((a, b) => {
+  for (const [, slotData] of slots) {
+    slotData.iterations.sort((a, b) => {
       const aNum = parseInt((a.label.match(/\d+/) || ["0"])[0]);
       const bNum = parseInt((b.label.match(/\d+/) || ["0"])[0]);
-      return aNum - bNum;
+      if (aNum !== bNum) return aNum - bNum;
+      return a.label.localeCompare(b.label);
     });
-    result.push({ slot, iterations });
+    result.push(slotData);
   }
-  result.sort((a, b) => a.slot.localeCompare(b.slot));
+  result.sort((a, b) => {
+    const groupCompare = a.group.localeCompare(b.group);
+    if (groupCompare !== 0) return groupCompare;
+    return a.page.localeCompare(b.page);
+  });
   return result;
 }
 
 // ========== Auto-Versioning ==========
 
-function nextVersionPath(page) {
-  const pagesDir = path.join(pagesRoot, "factory/pages", page);
+function nextVersionPath(group, page) {
+  const cleanGroup = sanitizePathPart(group);
+  const cleanPage = sanitizePathPart(page);
+  const relativeDir = cleanGroup ? `${cleanGroup}/${cleanPage}` : cleanPage;
+  const pagesDir = path.join(pagesRoot, "factory/pages", relativeDir);
   fs.mkdirSync(pagesDir, { recursive: true });
   const existing = fs.readdirSync(pagesDir).filter(f => f.endsWith(".html"));
   let maxVersion = 0;
@@ -541,9 +594,10 @@ function nextVersionPath(page) {
   }
   const next = maxVersion + 1;
   return {
-    filePath: path.join(pagesDir, `${page}-v${next}.html`),
-    relativePath: `${page}/${page}-v${next}.html`,
+    filePath: path.join(pagesDir, `${cleanPage}-v${next}.html`),
+    relativePath: `${relativeDir}/${cleanPage}-v${next}.html`,
     version: `v${next}`,
+    pagePath: relativeDir,
   };
 }
 
@@ -634,14 +688,20 @@ async function handleWrite(req, res) {
     jsonResponse(res, 400, { error: "Missing page or content" });
     return;
   }
-  const page = body.page.replace(/[^a-zA-Z0-9_-]/g, "");
+  const page = sanitizePathPart(body.page);
   if (!page) {
     jsonResponse(res, 400, { error: "Invalid page name" });
     return;
   }
-  const { filePath, relativePath, version } = nextVersionPath(page);
+  const rawGroup = body.group == null ? "" : String(body.group).trim();
+  const group = sanitizePathPart(rawGroup);
+  if (rawGroup && !group) {
+    jsonResponse(res, 400, { error: "Invalid group name" });
+    return;
+  }
+  const { filePath, relativePath, version, pagePath } = nextVersionPath(group, page);
   fs.writeFileSync(filePath, body.content);
-  jsonResponse(res, 200, { file: relativePath, version });
+  jsonResponse(res, 200, { file: relativePath, version, page: pagePath, group: group || null });
 }
 
 function handlePageStatus(req, res) {
@@ -679,7 +739,15 @@ function handlePageStatus(req, res) {
       }
     }
 
-    return { page, versions, latestFile, selectedOption, lastModified };
+    return {
+      page,
+      group: slotData.group,
+      name: slotData.page,
+      versions,
+      latestFile,
+      selectedOption,
+      lastModified,
+    };
   });
   jsonResponse(res, 200, result);
 }
@@ -768,7 +836,7 @@ const server = http.createServer((req, res) => {
     if (!tail || tail === "/") {
       servePortfolio(res);
     } else if (tail.startsWith("/")) {
-      serveFactory(res, tail.slice(1));
+      serveFactory(res, decodeFactoryPath(tail.slice(1)));
     } else {
       serveFactory(res);
     }

--- a/plugins/ctx-codex/skills/ctx-brainstorm/references/factory-guide.md
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/references/factory-guide.md
@@ -27,21 +27,23 @@ Content fragments are wrapped automatically by the frame template (dark theme, o
 
 For detailed prototyping with live style controls. Tell the user to open `http://localhost:<port>/factory`.
 
-**Storage:** `<project-root>/factory/pages/<page-name>/<page-name>-v<n>.html`
+**Storage:** `<project-root>/factory/pages/<group>/<page-name>/<page-name>-v<n>.html`
 
 Example:
 ```
 factory/pages/
-  landing/
-    landing-v1.html    ← first iteration
-    landing-v2.html    ← refined after feedback
+  tracker/
+    landing/
+      landing-v1.html
+      landing-v2.html
   pricing/
-    pricing-v1.html
+    pricing/
+      pricing-v1.html
 ```
 
 **The loop:**
-1. Write a full HTML page to `factory/pages/<page>/<page>-v<n>.html`
-2. Factory sidebar shows pages and versions — user clicks to preview
+1. Write a full HTML page to `factory/pages/<group>/<page>/<page>-v<n>.html`
+2. Factory sidebar shows collapsible group headers, page rows, and per-page versions — user clicks to preview
 3. User adjusts sidebar controls (colors, font, radius) to explore variations live
 4. User describes iteration in prompt bar → copies it → pastes in terminal
 5. You write the next version file

--- a/plugins/ctx/.claude-plugin/plugin.json
+++ b/plugins/ctx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctx",
   "description": "Personal development toolkit built on context economy — brainstorm, plan, execute, ship, QA. Every skill optimizes for minimal token spend with maximum signal.",
-  "version": "0.2.9.4",
+  "version": "0.2.9.6",
   "author": {
     "name": "Garo Nazarian"
   }

--- a/plugins/ctx/skills/ctx-brainstorm/SKILL.md
+++ b/plugins/ctx/skills/ctx-brainstorm/SKILL.md
@@ -26,7 +26,7 @@ before the spec is written and approved.
 3b. **Factory mode** — when the factory is running at `/factory`:
     - **Read `${CLAUDE_SKILL_DIR}/factory/references/factory-frontend.md` before generating any prototype.**
     - Read `factory/style-profile.json` for design tokens when generating prototypes (just-in-time — don't preload)
-    - **NEVER use Edit/Write to create prototypes directly.** Always use `POST http://localhost:<port>/api/write` with `{ "page": "<name>", "content": "<html>" }` — this auto-versions, reloads the factory, and respects the cross-repo guard. Direct file writes to `factory/pages/` in another repo will be blocked by `worktree-guard.sh`.
+    - **NEVER use Edit/Write to create prototypes directly.** Always use `POST http://localhost:<port>/api/write` with `{ "group": "<app-page>", "page": "<prototype-name>", "content": "<html>" }` — ask or infer the target app page first so new prototypes land under the right group. This auto-versions, reloads the factory, and respects the cross-repo guard. Direct file writes to `factory/pages/` in another repo will be blocked by `worktree-guard.sh`.
     - Read `<screen-dir>/.events` for `option-select` (user clicked a choice) and `style` (user changed controls) events
     - Use `data-option` on comparison pages — see "Prototype structure" in factory-guide.md
 4. **Ask questions** — one at a time, prefer multiple choice, understand purpose/constraints/success criteria
@@ -138,7 +138,7 @@ Present this handoff when the user approves a factory prototype:
 
 > Prototype `<page>-v<N>` approved.
 > - **Target repo:** `<project-dir from --project-dir>`
-> - **Prototype:** `factory/pages/<page>/<page>-v<N>.html`
+> - **Prototype:** `factory/pages/<group>/<page>/<page>-v<N>.html`
 > - **Replaces:** `<component path from discussion>`
 >
 > Next: `/ctx-worktree` in the target project, then `/ctx-plan` to port the prototype to React + Tailwind.

--- a/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
@@ -55,6 +55,23 @@
     min-width: 180px;
   }
   .proto-select:focus { outline: none; border-color: #818cf8; }
+  .page-nav {
+    display: flex;
+    gap: 0.3rem;
+  }
+  .page-nav-btn {
+    background: #0f172a;
+    color: #94a3b8;
+    border: 1px solid #334155;
+    border-radius: 4px;
+    width: 28px;
+    height: 28px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: all 0.12s;
+  }
+  .page-nav-btn:hover:not(:disabled) { border-color: #818cf8; color: #c7d2fe; }
+  .page-nav-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
   /* Viewport pills */
   .viewport-pills {
@@ -158,6 +175,45 @@
   }
 
   /* Pages section */
+  .page-group {
+    margin-bottom: 0.55rem;
+  }
+  .page-group-header {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.28rem 0.1rem 0.38rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+  .page-group-title {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #64748b;
+  }
+  .page-group-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+  }
+  .page-group-count {
+    font-size: 0.6rem;
+    color: #475569;
+  }
+  .page-group-chevron {
+    font-size: 0.72rem;
+    color: #64748b;
+  }
+  .page-group-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 0.12rem;
+  }
   .page-row {
     display: flex;
     align-items: center;
@@ -503,6 +559,10 @@
     <button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()" title="Toggle sidebar" aria-label="Toggle sidebar">&#9776;</button>
     <span class="top-bar-title">Tinker Factory</span>
     <span class="top-bar-context" id="top-bar-context"></span>
+    <div class="page-nav">
+      <button class="page-nav-btn" id="page-prev" onclick="goToAdjacentPage(-1)" title="Previous page" aria-label="Previous page">&larr;</button>
+      <button class="page-nav-btn" id="page-next" onclick="goToAdjacentPage(1)" title="Next page" aria-label="Next page">&rarr;</button>
+    </div>
     <select class="proto-select" id="proto-select" onchange="selectProtoFromDropdown(this.value)">
       <option value="">Loading slots...</option>
     </select>
@@ -578,6 +638,8 @@ var allSlots = [];
 var compareMode = false;
 var compareItems = [];
 var currentViewport = 'desktop';
+var expandedGroups = {};
+var previewFileBase = '/page?file=';
 
 // --- Sidebar collapse ---
 // Default collapsed; user preference persisted in localStorage.
@@ -612,6 +674,81 @@ function makeText(tag, className, text) {
   return el;
 }
 
+function buildPreviewUrl(filePath) {
+  return previewFileBase + encodeURIComponent(filePath);
+}
+
+function findSlot(slotName) {
+  for (var i = 0; i < allSlots.length; i++) {
+    if (allSlots[i].slot === slotName) return allSlots[i];
+  }
+  return null;
+}
+
+function getGroupName(slotData) {
+  return slotData && slotData.group ? slotData.group : 'Ungrouped';
+}
+
+function getPageLabel(slotData) {
+  return slotData ? (slotData.page || slotData.slot) : '';
+}
+
+function getPageContextLabel(slotData) {
+  if (!slotData) return '';
+  return getGroupName(slotData) === 'Ungrouped'
+    ? getPageLabel(slotData)
+    : getGroupName(slotData) + ' / ' + getPageLabel(slotData);
+}
+
+function updatePageNavButtons() {
+  var prev = document.getElementById('page-prev');
+  var next = document.getElementById('page-next');
+  var index = -1;
+
+  for (var i = 0; i < allSlots.length; i++) {
+    if (allSlots[i].slot === activePage) {
+      index = i;
+      break;
+    }
+  }
+
+  prev.disabled = index <= 0;
+  next.disabled = index === -1 || index >= allSlots.length - 1;
+}
+
+function goToAdjacentPage(direction) {
+  if (!activePage) return;
+  for (var i = 0; i < allSlots.length; i++) {
+    if (allSlots[i].slot === activePage) {
+      var target = allSlots[i + direction];
+      if (target) activatePage(target.slot, true);
+      return;
+    }
+  }
+}
+
+function renderProtoSelect() {
+  var protoSelect = document.getElementById('proto-select');
+  clearChildren(protoSelect);
+
+  var slotData = findSlot(activePage);
+  if (!slotData) {
+    var emptyOpt = document.createElement('option');
+    emptyOpt.value = '';
+    emptyOpt.textContent = 'Select a page';
+    protoSelect.appendChild(emptyOpt);
+    return;
+  }
+
+  slotData.iterations.forEach(function(iter) {
+    var opt = document.createElement('option');
+    opt.value = iter.file;
+    opt.textContent = iter.label;
+    if (iter.file === activeFile) opt.selected = true;
+    protoSelect.appendChild(opt);
+  });
+}
+
 // --- Viewport ---
 function setViewport(v) {
   currentViewport = v;
@@ -639,10 +776,11 @@ function setViewport(v) {
 // --- Top bar context ---
 function updateTopBarContext() {
   var ctx = document.getElementById('top-bar-context');
-  if (activePage && activeVersion) {
-    ctx.textContent = activePage + ' / ' + activeVersion;
-  } else if (activePage) {
-    ctx.textContent = activePage;
+  var slotData = findSlot(activePage);
+  if (slotData && activeVersion) {
+    ctx.textContent = getPageContextLabel(slotData) + ' / ' + activeVersion;
+  } else if (slotData) {
+    ctx.textContent = getPageContextLabel(slotData);
   } else {
     ctx.textContent = '';
   }
@@ -672,7 +810,7 @@ function setPreview(filePath) {
   if (placeholder) placeholder.style.display = 'none';
 
   var existing = container.querySelector('.preview-iframe');
-  var url = '/page?file=' + encodeURIComponent(filePath);
+  var url = buildPreviewUrl(filePath);
   if (existing) {
     existing.src = url;
   } else {
@@ -703,48 +841,120 @@ function setPreview(filePath) {
 
 function selectProtoFromDropdown(filePath) {
   if (!filePath) return;
-  for (var s = 0; s < allSlots.length; s++) {
-    var slotData = allSlots[s];
-    for (var it = 0; it < slotData.iterations.length; it++) {
-      var iter = slotData.iterations[it];
-      if (iter.file === filePath) {
-        activatePage(slotData.slot, false);
-        activeVersion = iter.label;
-        setPreview(filePath);
-        sendEvent({ type: 'select', slot: slotData.slot, iteration: iter.slug.split('--')[1] || iter.slug });
-        return;
-      }
+  var slotData = findSlot(activePage);
+  if (!slotData) return;
+  for (var it = 0; it < slotData.iterations.length; it++) {
+    var iter = slotData.iterations[it];
+    if (iter.file === filePath) {
+      activeVersion = iter.label;
+      setPreview(filePath);
+      sendEvent({ type: 'select', slot: slotData.slot, iteration: iter.slug.split('--')[1] || iter.slug });
+      return;
     }
   }
-  setPreview(filePath);
+}
+
+function toggleGroup(groupName) {
+  expandedGroups[groupName] = !expandedGroups[groupName];
+  renderPagesList();
+}
+
+function renderPagesList() {
+  var pagesList = document.getElementById('pages-list');
+  clearChildren(pagesList);
+
+  if (!allSlots || allSlots.length === 0) {
+    pagesList.appendChild(makeText('span', 'empty-hint', 'No prototype pages found'));
+    return;
+  }
+
+  var grouped = {};
+  var order = [];
+  allSlots.forEach(function(slotData) {
+    var groupName = getGroupName(slotData);
+    if (!grouped[groupName]) {
+      grouped[groupName] = [];
+      order.push(groupName);
+      if (expandedGroups[groupName] == null) expandedGroups[groupName] = true;
+    }
+    grouped[groupName].push(slotData);
+  });
+
+  order.forEach(function(groupName) {
+    var group = document.createElement('div');
+    group.className = 'page-group';
+
+    var header = document.createElement('button');
+    header.className = 'page-group-header';
+    header.type = 'button';
+    header.onclick = function() { toggleGroup(groupName); };
+
+    header.appendChild(makeText('span', 'page-group-title', groupName));
+
+    var meta = document.createElement('span');
+    meta.className = 'page-group-meta';
+    meta.appendChild(makeText('span', 'page-group-count', grouped[groupName].length + ''));
+    meta.appendChild(makeText('span', 'page-group-chevron', expandedGroups[groupName] ? '\u25be' : '\u25b8'));
+    header.appendChild(meta);
+    group.appendChild(header);
+
+    var rows = document.createElement('div');
+    rows.className = 'page-group-rows';
+    rows.style.display = expandedGroups[groupName] ? '' : 'none';
+
+    grouped[groupName].forEach(function(slotData) {
+      var row = document.createElement('div');
+      row.className = 'page-row' + (slotData.slot === activePage ? ' active' : '');
+      row.dataset.slot = slotData.slot;
+
+      row.appendChild(makeText('span', 'page-row-name', getPageLabel(slotData)));
+      row.appendChild(makeText('span', 'page-row-count', slotData.iterations.length + ''));
+      row.onclick = function() { activatePage(slotData.slot, true); };
+
+      rows.appendChild(row);
+    });
+
+    group.appendChild(rows);
+    pagesList.appendChild(group);
+  });
+}
+
+function selectInitialPage() {
+  var target = window.__factoryPage;
+  if (target && findSlot(target)) {
+    activatePage(target, true);
+    return;
+  }
+  if (allSlots.length > 0) {
+    activatePage(allSlots[0].slot, true);
+  } else {
+    updatePageNavButtons();
+  }
 }
 
 // --- Pages ---
-function activatePage(slotName, autoSelectFirst) {
-  activePage = slotName;
+function activatePage(slotName, autoSelectLatest) {
+  var slotData = findSlot(slotName);
+  if (!slotData) return;
 
-  var rows = document.querySelectorAll('.page-row');
-  for (var i = 0; i < rows.length; i++) {
-    rows[i].classList.toggle('active', rows[i].dataset.slot === slotName);
-  }
+  activePage = slotName;
+  renderPagesList();
 
   var versionsSection = document.getElementById('versions-section');
   versionsSection.style.display = '';
   renderVersionPills(slotName);
+  renderProtoSelect();
+  updatePageNavButtons();
 
-  if (autoSelectFirst) {
-    var slotData = null;
-    for (var s = 0; s < allSlots.length; s++) {
-      if (allSlots[s].slot === slotName) { slotData = allSlots[s]; break; }
-    }
-    if (slotData && slotData.iterations.length > 0) {
-      var last = slotData.iterations[slotData.iterations.length - 1];
-      activeVersion = last.label;
-      setPreview(last.file);
-      sendEvent({ type: 'select', slot: slotName, iteration: last.slug.split('--')[1] || last.slug });
-    }
+  if (autoSelectLatest && slotData.iterations.length > 0) {
+    var last = slotData.iterations[slotData.iterations.length - 1];
+    activeVersion = last.label;
+    setPreview(last.file);
+    sendEvent({ type: 'select', slot: slotName, iteration: last.slug.split('--')[1] || last.slug });
+    return;
   }
 
+  updateVersionPills();
   updateTopBarContext();
 }
 
@@ -752,10 +962,7 @@ function renderVersionPills(slotName) {
   var pillsEl = document.getElementById('version-pills');
   clearChildren(pillsEl);
 
-  var slotData = null;
-  for (var s = 0; s < allSlots.length; s++) {
-    if (allSlots[s].slot === slotName) { slotData = allSlots[s]; break; }
-  }
+  var slotData = findSlot(slotName);
   if (!slotData) return;
 
   slotData.iterations.forEach(function(iter) {
@@ -765,13 +972,11 @@ function renderVersionPills(slotName) {
     pill.dataset.file = iter.file;
     pill.dataset.label = iter.label;
     pill.title = iter.file;
-    (function(sn, slug, file, label) {
-      pill.onclick = function() {
-        activeVersion = label;
-        setPreview(file);
-        sendEvent({ type: 'select', slot: sn, iteration: slug.split('--')[1] || slug });
-      };
-    })(slotName, iter.slug, iter.file, iter.label);
+    pill.onclick = function() {
+      activeVersion = iter.label;
+      setPreview(iter.file);
+      sendEvent({ type: 'select', slot: slotName, iteration: iter.slug.split('--')[1] || iter.slug });
+    };
     pillsEl.appendChild(pill);
   });
 }
@@ -785,20 +990,21 @@ function updateVersionPills() {
 
 // --- Slot rendering ---
 function renderSlots(slots) {
-  allSlots = slots;
+  allSlots = slots || [];
 
-  var pagesList = document.getElementById('pages-list');
   var protoSelect = document.getElementById('proto-select');
   var versionsSection = document.getElementById('versions-section');
 
-  clearChildren(pagesList);
+  activeFile = null;
+  activePage = null;
+  activeVersion = null;
+
   clearChildren(protoSelect);
   versionsSection.style.display = 'none';
   clearChildren(document.getElementById('version-pills'));
+  renderPagesList();
 
-  if (!slots || slots.length === 0) {
-    pagesList.appendChild(makeText('span', 'empty-hint', 'No prototype pages found'));
-
+  if (!allSlots.length) {
     var noOpt = document.createElement('option');
     noOpt.value = '';
     noOpt.textContent = 'No prototypes';
@@ -809,42 +1015,12 @@ function renderSlots(slots) {
       ph.style.display = '';
       document.getElementById('preview-placeholder-msg').textContent = 'No prototype files found in factory/pages/';
     }
+    updateTopBarContext();
+    updatePageNavButtons();
     return;
   }
 
-  var blankOpt = document.createElement('option');
-  blankOpt.value = '';
-  blankOpt.textContent = 'Jump to...';
-  protoSelect.appendChild(blankOpt);
-
-  slots.forEach(function(slotData) {
-    var slotName = slotData.slot;
-    var iterations = slotData.iterations;
-
-    var row = document.createElement('div');
-    row.className = 'page-row';
-    row.dataset.slot = slotName;
-
-    row.appendChild(makeText('span', 'page-row-name', slotName));
-    row.appendChild(makeText('span', 'page-row-count', iterations.length + ''));
-
-    (function(sn) {
-      row.onclick = function() { activatePage(sn, true); };
-    })(slotName);
-
-    pagesList.appendChild(row);
-
-    iterations.forEach(function(iter) {
-      var opt = document.createElement('option');
-      opt.value = iter.file;
-      opt.textContent = slotName + ' / ' + iter.label;
-      protoSelect.appendChild(opt);
-    });
-  });
-
-  if (slots.length > 0) {
-    activatePage(slots[0].slot, true);
-  }
+  selectInitialPage();
 }
 
 // --- Load slots ---
@@ -852,15 +1028,6 @@ fetch('/api/slots')
   .then(function(r) { return r.json(); })
   .then(function(slots) {
     renderSlots(slots);
-    if (window.__factoryPage) {
-      var target = window.__factoryPage;
-      for (var s = 0; s < allSlots.length; s++) {
-        if (allSlots[s].slot === target) {
-          activatePage(target, true);
-          return;
-        }
-      }
-    }
   })
   .catch(function(err) {
     var ph = document.getElementById('preview-placeholder');
@@ -872,6 +1039,7 @@ fetch('/api/slots')
     errOpt.value = '';
     errOpt.textContent = 'Error loading';
     document.getElementById('proto-select').appendChild(errOpt);
+    updatePageNavButtons();
   });
 
 // --- Style Controls ---
@@ -1304,7 +1472,7 @@ function enterCompareMode(items) {
     if (item.file) {
       var iframe = document.createElement('iframe');
       iframe.className = 'compare-iframe';
-      iframe.src = '/page?file=' + encodeURIComponent(item.file);
+      iframe.src = buildPreviewUrl(item.file);
       col.appendChild(iframe);
     } else {
       var notFound = document.createElement('div');
@@ -1334,7 +1502,7 @@ function exitCompareMode() {
     savedChildren = null;
     var iframe = document.querySelector('.preview-iframe');
     if (iframe && activeFile) {
-      iframe.src = '/page?file=' + encodeURIComponent(activeFile);
+      iframe.src = buildPreviewUrl(activeFile);
     }
   }
 }

--- a/plugins/ctx/skills/ctx-brainstorm/factory/portfolio.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/portfolio.html
@@ -100,6 +100,11 @@
     color: #a5b4fc;
     border: 1px solid #312e81;
   }
+  .badge-group {
+    background: #172554;
+    color: #93c5fd;
+    border: 1px solid #1d4ed8;
+  }
   .badge-selected {
     background: #042f2e;
     color: #5eead4;
@@ -138,6 +143,12 @@
 </div>
 
 <script>
+function buildFactoryHref(page) {
+  return '/factory/' + page.split('/').map(function(part) {
+    return encodeURIComponent(part);
+  }).join('/');
+}
+
 function relativeTime(iso) {
   if (!iso) return '';
   var diff = Date.now() - new Date(iso).getTime();
@@ -166,7 +177,7 @@ function renderCards(pages) {
   pages.forEach(function(p) {
     var card = document.createElement('div');
     card.className = 'card';
-    card.onclick = function() { window.location.href = '/factory/' + encodeURIComponent(p.page); };
+    card.onclick = function() { window.location.href = buildFactoryHref(p.page); };
 
     // Thumbnail
     var thumb = document.createElement('div');
@@ -186,7 +197,7 @@ function renderCards(pages) {
 
     var name = document.createElement('div');
     name.className = 'card-name';
-    name.textContent = p.page;
+    name.textContent = p.name || p.page;
     body.appendChild(name);
 
     var meta = document.createElement('div');
@@ -196,6 +207,13 @@ function renderCards(pages) {
     vBadge.className = 'badge badge-versions';
     vBadge.textContent = p.versions + (p.versions === 1 ? ' version' : ' versions');
     meta.appendChild(vBadge);
+
+    if (p.group && p.group !== 'Ungrouped') {
+      var gBadge = document.createElement('span');
+      gBadge.className = 'badge badge-group';
+      gBadge.textContent = p.group;
+      meta.appendChild(gBadge);
+    }
 
     if (p.selectedOption) {
       var sBadge = document.createElement('span');

--- a/plugins/ctx/skills/ctx-brainstorm/factory/references/factory-frontend.md
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/references/factory-frontend.md
@@ -52,7 +52,7 @@ Apply the Apple copy formula:
 ## Phase 3 — Prototype Implementation
 
 ### Delivery
-**Always** `POST /api/write` with `{ "page": "<name>", "content": "<html>" }`. Never Edit/Write directly — the cross-repo guard blocks it and you lose auto-versioning.
+**Always** `POST /api/write` with `{ "group": "<app-page>", "page": "<name>", "content": "<html>" }`. Ask or infer the target app page before writing. Never Edit/Write directly — the cross-repo guard blocks it and you lose auto-versioning.
 
 ### Code Rules
 - **Vanilla HTML/CSS/JS only.** No build step, no frameworks, no imports.

--- a/plugins/ctx/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/server.js
@@ -420,6 +420,18 @@ function serveFactory(res, targetPage) {
   res.end(content);
 }
 
+function decodeFactoryPath(value) {
+  try {
+    return value
+      .split("/")
+      .filter(Boolean)
+      .map(segment => decodeURIComponent(segment))
+      .join("/");
+  } catch {
+    return value;
+  }
+}
+
 function servePage(res, filePath) {
   if (!pagesRoot) {
     res.writeHead(400, { "Content-Type": "text/plain" });
@@ -475,6 +487,31 @@ function serveBrainstorm(res) {
 
 // ========== Slot Scanner ==========
 
+const DEFAULT_FACTORY_GROUP = "Ungrouped";
+
+function describeSlotPath(relativeDir) {
+  const segments = relativeDir.split("/").filter(Boolean);
+  if (segments.length === 0) {
+    return { group: DEFAULT_FACTORY_GROUP, page: "root", slot: "root" };
+  }
+  if (segments.length === 1) {
+    return {
+      group: DEFAULT_FACTORY_GROUP,
+      page: segments[0],
+      slot: segments[0],
+    };
+  }
+  return {
+    group: segments[0],
+    page: segments.slice(1).join("/"),
+    slot: segments.join("/"),
+  };
+}
+
+function sanitizePathPart(value) {
+  return String(value || "").trim().replace(/[^a-zA-Z0-9_-]/g, "");
+}
+
 function scanSlots() {
   if (!pagesRoot) return [];
   const factoryPagesDir = path.join(pagesRoot, "factory/pages");
@@ -497,17 +534,25 @@ function scanSlots() {
       if (stat.isDirectory()) {
         scan(fullPath, prefix ? prefix + "/" + entry.name : entry.name);
       } else if (entry.name.endsWith(".html")) {
-        const slotName = prefix || "root";
         const filePath = prefix ? prefix + "/" + entry.name : entry.name;
         const baseName = entry.name.replace(/\.html$/, "");
+        const slotMeta = describeSlotPath(prefix || "");
+        const slotName = slotMeta.slot;
 
         // Parse version: name-v2 → "v2", name-v2-bold → "v2-bold", name → "v1"
         const vMatch = baseName.match(/-v(\d+.*)$/);
         const label = vMatch ? "v" + vMatch[1] : "v1";
         const slug = slotName + "--" + baseName;
 
-        if (!slots.has(slotName)) slots.set(slotName, []);
-        slots.get(slotName).push({ slug, label, file: filePath });
+        if (!slots.has(slotName)) {
+          slots.set(slotName, {
+            group: slotMeta.group,
+            page: slotMeta.page,
+            slot: slotName,
+            iterations: [],
+          });
+        }
+        slots.get(slotName).iterations.push({ slug, label, file: filePath });
       }
     }
   }
@@ -516,22 +561,30 @@ function scanSlots() {
 
   // Sort iterations within each slot by version number
   const result = [];
-  for (const [slot, iterations] of slots) {
-    iterations.sort((a, b) => {
+  for (const [, slotData] of slots) {
+    slotData.iterations.sort((a, b) => {
       const aNum = parseInt((a.label.match(/\d+/) || ["0"])[0]);
       const bNum = parseInt((b.label.match(/\d+/) || ["0"])[0]);
-      return aNum - bNum;
+      if (aNum !== bNum) return aNum - bNum;
+      return a.label.localeCompare(b.label);
     });
-    result.push({ slot, iterations });
+    result.push(slotData);
   }
-  result.sort((a, b) => a.slot.localeCompare(b.slot));
+  result.sort((a, b) => {
+    const groupCompare = a.group.localeCompare(b.group);
+    if (groupCompare !== 0) return groupCompare;
+    return a.page.localeCompare(b.page);
+  });
   return result;
 }
 
 // ========== Auto-Versioning ==========
 
-function nextVersionPath(page) {
-  const pagesDir = path.join(pagesRoot, "factory/pages", page);
+function nextVersionPath(group, page) {
+  const cleanGroup = sanitizePathPart(group);
+  const cleanPage = sanitizePathPart(page);
+  const relativeDir = cleanGroup ? `${cleanGroup}/${cleanPage}` : cleanPage;
+  const pagesDir = path.join(pagesRoot, "factory/pages", relativeDir);
   fs.mkdirSync(pagesDir, { recursive: true });
   const existing = fs.readdirSync(pagesDir).filter(f => f.endsWith(".html"));
   let maxVersion = 0;
@@ -541,9 +594,10 @@ function nextVersionPath(page) {
   }
   const next = maxVersion + 1;
   return {
-    filePath: path.join(pagesDir, `${page}-v${next}.html`),
-    relativePath: `${page}/${page}-v${next}.html`,
+    filePath: path.join(pagesDir, `${cleanPage}-v${next}.html`),
+    relativePath: `${relativeDir}/${cleanPage}-v${next}.html`,
     version: `v${next}`,
+    pagePath: relativeDir,
   };
 }
 
@@ -622,14 +676,20 @@ async function handleWrite(req, res) {
     jsonResponse(res, 400, { error: "Missing page or content" });
     return;
   }
-  const page = body.page.replace(/[^a-zA-Z0-9_-]/g, "");
+  const page = sanitizePathPart(body.page);
   if (!page) {
     jsonResponse(res, 400, { error: "Invalid page name" });
     return;
   }
-  const { filePath, relativePath, version } = nextVersionPath(page);
+  const rawGroup = body.group == null ? "" : String(body.group).trim();
+  const group = sanitizePathPart(rawGroup);
+  if (rawGroup && !group) {
+    jsonResponse(res, 400, { error: "Invalid group name" });
+    return;
+  }
+  const { filePath, relativePath, version, pagePath } = nextVersionPath(group, page);
   fs.writeFileSync(filePath, body.content);
-  jsonResponse(res, 200, { file: relativePath, version });
+  jsonResponse(res, 200, { file: relativePath, version, page: pagePath, group: group || null });
 }
 
 function handlePageStatus(req, res) {
@@ -667,7 +727,15 @@ function handlePageStatus(req, res) {
       }
     }
 
-    return { page, versions, latestFile, selectedOption, lastModified };
+    return {
+      page,
+      group: slotData.group,
+      name: slotData.page,
+      versions,
+      latestFile,
+      selectedOption,
+      lastModified,
+    };
   });
   jsonResponse(res, 200, result);
 }
@@ -756,7 +824,7 @@ const server = http.createServer((req, res) => {
     if (!tail || tail === "/") {
       servePortfolio(res);
     } else if (tail.startsWith("/")) {
-      serveFactory(res, tail.slice(1));
+      serveFactory(res, decodeFactoryPath(tail.slice(1)));
     } else {
       serveFactory(res);
     }

--- a/plugins/ctx/skills/ctx-brainstorm/references/factory-guide.md
+++ b/plugins/ctx/skills/ctx-brainstorm/references/factory-guide.md
@@ -27,21 +27,23 @@ Content fragments are wrapped automatically by the frame template (dark theme, o
 
 For detailed prototyping with live style controls. Tell the user to open `http://localhost:<port>/factory`.
 
-**Storage:** `<project-root>/factory/pages/<page-name>/<page-name>-v<n>.html`
+**Storage:** `<project-root>/factory/pages/<group>/<page-name>/<page-name>-v<n>.html`
 
 Example:
 ```
 factory/pages/
-  landing/
-    landing-v1.html    ← first iteration
-    landing-v2.html    ← refined after feedback
+  tracker/
+    landing/
+      landing-v1.html
+      landing-v2.html
   pricing/
-    pricing-v1.html
+    pricing/
+      pricing-v1.html
 ```
 
 **The loop:**
-1. Write a full HTML page to `factory/pages/<page>/<page>-v<n>.html`
-2. Factory sidebar shows pages and versions — user clicks to preview
+1. Write a full HTML page to `factory/pages/<group>/<page>/<page>-v<n>.html`
+2. Factory sidebar shows collapsible group headers, page rows, and per-page versions — user clicks to preview
 3. User adjusts sidebar controls (colors, font, radius) to explore variations live
 4. User describes iteration in prompt bar → copies it → pastes in terminal
 5. You write the next version file


### PR DESCRIPTION
## Summary
- group factory prototypes by app page and support grouped deep links in the factory server
- update the Claude and Codex factory UIs with grouped sidebar sections, page arrows, and version dropdowns scoped to the active page
- align brainstorm docs, manifests, changelog, and ignore factory runtime state files

## Testing
- node --check plugins/ctx/skills/ctx-brainstorm/factory/server.js
- node --check plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
- bash plugins/ctx/scripts/test-scripts.sh with commit.gpgsign=false (existing unrelated worktree-post-setup symlink test failures remain)
- bash plugins/ctx-codex/scripts/test-scripts.sh with commit.gpgsign=false (existing unrelated .codex test harness directory bug remains)