### PR TITLE
fix(factory): parse v<N>-prefix filenames in version label scanner

### DIFF
--- a/plugins/ctx/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/server.js
@@ -539,8 +539,8 @@ function scanSlots() {
         const slotMeta = describeSlotPath(prefix || "");
         const slotName = slotMeta.slot;
 
-        // Parse version: name-v2 → "v2", name-v2-bold → "v2-bold", name → "v1"
-        const vMatch = baseName.match(/-v(\d+.*)$/);
+        // Parse version: v2-name → "v2", name-v2 → "v2", name-v2-bold → "v2-bold", name → "v1"
+        const vMatch = baseName.match(/^v(\d+)/) || baseName.match(/-v(\d+.*)$/);
         const label = vMatch ? "v" + vMatch[1] : "v1";
         const slug = slotName + "--" + baseName;
 
@@ -589,7 +589,7 @@ function nextVersionPath(group, page) {
   const existing = fs.readdirSync(pagesDir).filter(f => f.endsWith(".html"));
   let maxVersion = 0;
   for (const f of existing) {
-    const m = f.match(/-v(\d+)/);
+    const m = f.match(/^v(\d+)/) || f.match(/-v(\d+)/);
     if (m) maxVersion = Math.max(maxVersion, parseInt(m[1]));
   }
   const next = maxVersion + 1;


### PR DESCRIPTION
## Problem

Every factory page was showing as **v1** regardless of the actual file version. All 17+ iterations of `my-lab-landing`, all 5 of `my-protocol-playful`, etc. — all labelled v1 in the viewer.

## Root cause

Two regex sites in `server.js` only matched the suffix convention (`name-v2.html`):

```js
// scanSlots — label assignment
const vMatch = baseName.match(/-v(\d+.*)$/);  // ❌ never matched

// nextVersionPath — max-version scan
const m = f.match(/-v(\d+)/);                 // ❌ never matched
```

Factory pages use a **prefix** convention (`v17-integrated-peptide-gravity.html`). Since `-v` never appears before the digits in that format, `vMatch` was always `null` and the default `"v1"` fired for every file. `nextVersionPath` had the same blind spot — it would compute `maxVersion = 0` and generate `v1` for every new iteration.

## Fix

Added `^v(\d+)` as a first-try match in both sites; kept the suffix pattern as `||` fallback for backwards compatibility with any pages using the old convention:

```js
// scanSlots
const vMatch = baseName.match(/^v(\d+)/) || baseName.match(/-v(\d+.*)$/);

// nextVersionPath
const m = f.match(/^v(\d+)/) || f.match(/-v(\d+)/);
```

## Test plan

- [ ] Open factory at `/factory` — pages with `v<N>-` prefix filenames now show correct version labels (v2, v10, v17, etc.)
- [ ] Brainstorm iterate on a page with existing `v<N>-` prefix files — next version is `v<N+1>`, not `v1`
- [ ] Pages using legacy `name-v2.html` suffix convention still label correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)