### PR TITLE
docs(factory): add prototype fidelity mode gate

### DIFF
--- a/plugins/ctx-codex/skills/ctx-brainstorm/SKILL.md
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/SKILL.md
@@ -25,6 +25,7 @@ before the spec is written and approved.
 3. **Visual factory gate** — before asking any questions, evaluate: will this brainstorm involve architecture diagrams, layout comparisons, option cards, or spatial content? If yes, offer the factory as its own message and wait for the user's response before continuing (read `./references/factory-guide.md`). If the project has a `factory/style-profile.json`, suggest factory mode (`/factory` URL) for style-aware prototyping.
 3b. **Factory mode** — when the factory is running at `/factory`:
     - **Read `./factory/references/factory-frontend.md` before generating any prototype.**
+    - Confirm the requested fidelity from that reference before writing: `polished prototype` by default, `wireframe` only when the user explicitly chooses speed/structure over finish.
     - Read `factory/style-profile.json` for design tokens when generating prototypes (just-in-time — don't preload)
     - **NEVER use Edit/Write to create prototypes directly.** Always use `POST http://localhost:<port>/api/write` with `{ "group": "<app-page>", "page": "<prototype-name>", "content": "<html>" }` — ask or infer the target app page first so new prototypes land under the right group. This auto-versions and reloads the factory.
     - Read `<screen-dir>/.events` for `option-select` (user clicked a choice) and `style` (user changed controls) events

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/references/factory-frontend.md
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/references/factory-frontend.md
@@ -9,8 +9,26 @@
 Do NOT write prototype HTML until you have:
 1. Identified the competitive position (Phase 1 — even briefly)
 2. Written the copy first (headlines, labels, CTAs, empty states)
+3. Confirmed the prototype fidelity mode (default: polished prototype)
 
 Prototypes with lorem ipsum or placeholder copy are plan failures.
+
+---
+
+## Fidelity Mode Gate
+
+Before generating the first version of any factory page, decide which mode the user wants:
+
+- **Polished prototype (default):** production-adjacent UI direction. Use real layout density, finished visual hierarchy, shaped assets/glyphs, realistic state copy, responsive behavior, and enough interaction/motion to judge the experience.
+- **Wireframe:** fast structure only. Use restrained styling, simple blocks, minimal motion, and only the fidelity needed to compare layout, flow, and information architecture.
+
+If the user has not chosen, ask once:
+
+> Do you want a polished prototype or a wireframe for this factory page?
+
+Do not call a page "polished" if it still has placeholder assets, generic boxes where a known product asset/glyph belongs, incomplete responsive states, or unreviewed visual hierarchy. For domain-specific assets, use the project's existing glyphs/assets when available; if the project has no asset, create a self-contained inline SVG/CSS stand-in that matches the intended product language.
+
+When the user asks for "high fidelity", "polished", "production-like", "looks real", "visual accurate", or provides screenshots, treat that as **Polished prototype** without asking again.
 
 ---
 
@@ -65,6 +83,7 @@ Apply the Apple copy formula:
 ### Quality Bar
 Before submitting the prototype, verify:
 - [ ] Real copy — no lorem ipsum, no "placeholder text"
+- [ ] Fidelity mode is satisfied — polished feels production-adjacent; wireframe stays intentionally structural
 - [ ] Responsive — works at 375px and 1280px
 - [ ] Animations are CSS-only, respect `prefers-reduced-motion`
 - [ ] Uses `--cp-*` variables with fallbacks

--- a/plugins/ctx/skills/ctx-brainstorm/SKILL.md
+++ b/plugins/ctx/skills/ctx-brainstorm/SKILL.md
@@ -25,6 +25,7 @@ before the spec is written and approved.
 3. **Visual factory gate** — before asking any questions, evaluate: will this brainstorm involve architecture diagrams, layout comparisons, option cards, or spatial content? If yes, offer the factory as its own message and wait for the user's response before continuing (read `${CLAUDE_SKILL_DIR}/references/factory-guide.md`). If the project has a `factory/style-profile.json`, suggest factory mode (`/factory` URL) for style-aware prototyping.
 3b. **Factory mode** — when the factory is running at `/factory`:
     - **Read `${CLAUDE_SKILL_DIR}/factory/references/factory-frontend.md` before generating any prototype.**
+    - Confirm the requested fidelity from that reference before writing: `polished prototype` by default, `wireframe` only when the user explicitly chooses speed/structure over finish.
     - Read `factory/style-profile.json` for design tokens when generating prototypes (just-in-time — don't preload)
     - **NEVER use Edit/Write to create prototypes directly.** Always use `POST http://localhost:<port>/api/write` with `{ "group": "<app-page>", "page": "<prototype-name>", "content": "<html>" }` — ask or infer the target app page first so new prototypes land under the right group. This auto-versions and reloads the factory.
     - Read `<screen-dir>/.events` for `option-select` (user clicked a choice) and `style` (user changed controls) events

--- a/plugins/ctx/skills/ctx-brainstorm/factory/references/factory-frontend.md
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/references/factory-frontend.md
@@ -9,8 +9,26 @@
 Do NOT write prototype HTML until you have:
 1. Identified the competitive position (Phase 1 — even briefly)
 2. Written the copy first (headlines, labels, CTAs, empty states)
+3. Confirmed the prototype fidelity mode (default: polished prototype)
 
 Prototypes with lorem ipsum or placeholder copy are plan failures.
+
+---
+
+## Fidelity Mode Gate
+
+Before generating the first version of any factory page, decide which mode the user wants:
+
+- **Polished prototype (default):** production-adjacent UI direction. Use real layout density, finished visual hierarchy, shaped assets/glyphs, realistic state copy, responsive behavior, and enough interaction/motion to judge the experience.
+- **Wireframe:** fast structure only. Use restrained styling, simple blocks, minimal motion, and only the fidelity needed to compare layout, flow, and information architecture.
+
+If the user has not chosen, ask once:
+
+> Do you want a polished prototype or a wireframe for this factory page?
+
+Do not call a page "polished" if it still has placeholder assets, generic boxes where a known product asset/glyph belongs, incomplete responsive states, or unreviewed visual hierarchy. For domain-specific assets, use the project's existing glyphs/assets when available; if the project has no asset, create a self-contained inline SVG/CSS stand-in that matches the intended product language.
+
+When the user asks for "high fidelity", "polished", "production-like", "looks real", "visual accurate", or provides screenshots, treat that as **Polished prototype** without asking again.
 
 ---
 
@@ -65,6 +83,7 @@ Apply the Apple copy formula:
 ### Quality Bar
 Before submitting the prototype, verify:
 - [ ] Real copy — no lorem ipsum, no "placeholder text"
+- [ ] Fidelity mode is satisfied — polished feels production-adjacent; wireframe stays intentionally structural
 - [ ] Responsive — works at 375px and 1280px
 - [ ] Animations are CSS-only, respect `prefers-reduced-motion`
 - [ ] Uses `--cp-*` variables with fallbacks


### PR DESCRIPTION
## Summary
- add a factory fidelity mode gate for polished prototypes vs wireframes
- default factory generation to polished prototypes unless the user explicitly chooses wireframe mode
- update both ctx and ctx-codex brainstorm skill copies

## Verification
- git diff --check
- cmp -s plugins/ctx-codex/skills/ctx-brainstorm/factory/references/factory-frontend.md plugins/ctx/skills/ctx-brainstorm/factory/references/factory-frontend.md