### PR TITLE
Improve CTX Factory portfolio chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.9.7 (2026-05-15)
+
+- **Factory portfolio chrome** — portfolio cards now use responsive preview scaling, larger readable metadata, grouped default sections, category-scoped URLs (`/factory?category=...`), and an explicit `All pages` escape path. The editor top bar now includes a stable `Factory` back link, keeps page/version controls fixed on the right, and removes the obsolete bottom prompt bar. Bare `/` redirects to `/factory` when no transient brainstorm preview exists.
+
 ## 0.2.9.6 (2026-04-22)
 
 - **Factory grouped navigation (CTX-46)** — factory prototypes can now be stored under `factory/pages/<group>/<page>/`, `scanSlots()` exposes group metadata, `/api/write` accepts a `group` field, the editor sidebar renders collapsible group sections, the top-bar version dropdown is scoped to the active page, and left/right arrows switch pages independently of version selection. Deep links and portfolio cards now support grouped page paths.

--- a/plugins/ctx-codex/.codex-plugin/plugin.json
+++ b/plugins/ctx-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ctx-codex",
-  "version": "0.2.9.6",
+  "version": "0.2.9.7",
   "description": "Context economy workflow toolkit for Codex: brainstorm, plan, execute, verify, ship, and manage worktree handoffs with minimal token spend.",
   "author": {
     "name": "Garo Nazarian",

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
@@ -297,11 +297,57 @@
     grid-template-columns: 1fr 1fr;
     gap: 0.35rem;
   }
+  .page-action-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.35rem;
+  }
+  .page-tool-btn {
+    background: #1e293b;
+    color: #94a3b8;
+    border: 1px solid #334155;
+    border-radius: 5px;
+    padding: 0.32rem 0.5rem;
+    font-size: 0.68rem;
+    cursor: pointer;
+    font-family: inherit;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+  .page-tool-btn:hover,
+  .page-tool-btn.active {
+    border-color: #818cf8;
+    color: #c7d2fe;
+  }
+  .page-tool-btn:disabled {
+    opacity: 0.5;
+    cursor: wait;
+  }
+  #page-rescan {
+    grid-column: 1 / -1;
+  }
   .page-results {
     font-size: 0.65rem;
     color: #64748b;
     margin: -0.15rem 0 0.45rem;
     font-family: 'SF Mono', 'Fira Code', monospace;
+  }
+  .page-versions {
+    display: none;
+    padding: 0.45rem 0;
+    border-top: 1px solid #1e293b;
+    border-bottom: 1px solid #1e293b;
+  }
+  .page-versions.visible {
+    display: block;
+  }
+  .page-versions-label {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: #64748b;
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
   .page-row {
     display: flex;
@@ -648,17 +694,20 @@
             <option value="category-asc">Category A-Z</option>
           </select>
         </div>
+        <div class="page-action-row">
+          <button class="page-tool-btn active" id="page-compact" type="button" onclick="setPageGroupMode('compact')">Compact</button>
+          <button class="page-tool-btn" id="page-expand" type="button" onclick="setPageGroupMode('expanded')">Expand</button>
+          <button class="page-tool-btn btn-rescan" id="page-rescan" type="button" onclick="triggerRescan()">Re-scan project</button>
+        </div>
+        <div class="page-versions" id="versions-section">
+          <span class="page-versions-label">Versions</span>
+          <div class="version-pills" id="version-pills">
+            <!-- Populated by JS -->
+          </div>
+        </div>
         <div class="page-results" id="page-results"></div>
       </div>
       <div id="pages-list">
-        <!-- Populated by JS -->
-      </div>
-    </div>
-
-    <!-- Versions section (shown when a page is active) -->
-    <div class="controls-section" id="versions-section" style="display:none;">
-      <div class="controls-section-title">Versions</div>
-      <div class="version-pills" id="version-pills">
         <!-- Populated by JS -->
       </div>
     </div>
@@ -693,6 +742,7 @@ var compareMode = false;
 var compareItems = [];
 var currentViewport = 'desktop';
 var expandedGroups = {};
+var pageGroupMode = 'compact';
 var previewFileBase = '/prototype?file=';
 var pageFilters = { query: '', category: '', sort: 'updated-desc' };
 
@@ -831,6 +881,32 @@ function updatePageFilters() {
   pageFilters.sort = sort ? sort.value : 'updated-desc';
   renderPagesList();
   updatePageNavButtons();
+}
+
+function getActiveGroupName() {
+  var activeSlot = findSlot(activePage);
+  return getGroupName(activeSlot);
+}
+
+function updatePageGroupModeButtons() {
+  var compact = document.getElementById('page-compact');
+  var expand = document.getElementById('page-expand');
+  if (compact) compact.classList.toggle('active', pageGroupMode === 'compact');
+  if (expand) expand.classList.toggle('active', pageGroupMode === 'expanded');
+}
+
+function setPageGroupMode(mode) {
+  pageGroupMode = mode === 'expanded' ? 'expanded' : 'compact';
+  var activeGroup = getActiveGroupName();
+  var groups = {};
+  allSlots.forEach(function(slotData) {
+    groups[getGroupName(slotData)] = true;
+  });
+  Object.keys(groups).forEach(function(groupName) {
+    expandedGroups[groupName] = pageGroupMode === 'expanded' || groupName === activeGroup;
+  });
+  updatePageGroupModeButtons();
+  renderPagesList();
 }
 
 function updatePageNavButtons() {
@@ -1007,7 +1083,9 @@ function renderPagesList() {
     if (!grouped[groupName]) {
       grouped[groupName] = [];
       order.push(groupName);
-      if (expandedGroups[groupName] == null) expandedGroups[groupName] = true;
+      if (expandedGroups[groupName] == null) {
+        expandedGroups[groupName] = pageGroupMode === 'expanded' || groupName === getActiveGroupName();
+      }
     }
     grouped[groupName].push(slotData);
   });
@@ -1071,10 +1149,17 @@ function activatePage(slotName, autoSelectLatest) {
   if (!slotData) return;
 
   activePage = slotName;
+  if (pageGroupMode === 'compact') {
+    var activeGroup = getGroupName(slotData);
+    Object.keys(expandedGroups).forEach(function(groupName) {
+      expandedGroups[groupName] = groupName === activeGroup;
+    });
+    expandedGroups[activeGroup] = true;
+  }
   renderPagesList();
 
   var versionsSection = document.getElementById('versions-section');
-  versionsSection.style.display = '';
+  versionsSection.classList.add('visible');
   renderVersionPills(slotName);
   renderProtoSelect();
   updatePageNavButtons();
@@ -1134,7 +1219,7 @@ function renderSlots(slots) {
   activeVersion = null;
 
   clearChildren(protoSelect);
-  versionsSection.style.display = 'none';
+  versionsSection.classList.remove('visible');
   clearChildren(document.getElementById('version-pills'));
   renderPagesList();
 
@@ -1492,8 +1577,7 @@ function loadStyleProfile() {
 }
 
 function triggerRescan() {
-  var container = document.getElementById('style-controls-content');
-  var btns = container.querySelectorAll('.btn-rescan');
+  var btns = document.querySelectorAll('.btn-rescan');
   btns.forEach(function(b) { b.disabled = true; b.textContent = 'Scanning...'; });
 
   fetch('/api/scan', { method: 'POST' })

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
@@ -299,20 +299,30 @@
   }
   .page-action-row {
     display: grid;
-    grid-template-columns: 1fr 1fr;
     gap: 0.35rem;
+  }
+  .page-mode-toggle {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    padding: 0.15rem;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    background: #0a0e17;
   }
   .page-tool-btn {
     background: #1e293b;
     color: #94a3b8;
-    border: 1px solid #334155;
-    border-radius: 5px;
+    border: 1px solid transparent;
+    border-radius: 4px;
     padding: 0.32rem 0.5rem;
     font-size: 0.68rem;
     cursor: pointer;
     font-family: inherit;
     transition: all 0.15s;
     white-space: nowrap;
+  }
+  .page-mode-toggle .page-tool-btn {
+    background: transparent;
   }
   .page-tool-btn:hover,
   .page-tool-btn.active {
@@ -324,7 +334,8 @@
     cursor: wait;
   }
   #page-rescan {
-    grid-column: 1 / -1;
+    width: 100%;
+    border-color: #334155;
   }
   .page-results {
     font-size: 0.65rem;
@@ -695,8 +706,10 @@
           </select>
         </div>
         <div class="page-action-row">
-          <button class="page-tool-btn active" id="page-compact" type="button" onclick="setPageGroupMode('compact')">Compact</button>
-          <button class="page-tool-btn" id="page-expand" type="button" onclick="setPageGroupMode('expanded')">Expand</button>
+          <div class="page-mode-toggle" role="group" aria-label="Page group display mode">
+            <button class="page-tool-btn active" id="page-compact" type="button" onclick="setPageGroupMode('compact')" aria-pressed="true">Compact</button>
+            <button class="page-tool-btn" id="page-expand" type="button" onclick="setPageGroupMode('expanded')" aria-pressed="false">Expand</button>
+          </div>
           <button class="page-tool-btn btn-rescan" id="page-rescan" type="button" onclick="triggerRescan()">Re-scan project</button>
         </div>
         <div class="page-versions" id="versions-section">
@@ -893,6 +906,8 @@ function updatePageGroupModeButtons() {
   var expand = document.getElementById('page-expand');
   if (compact) compact.classList.toggle('active', pageGroupMode === 'compact');
   if (expand) expand.classList.toggle('active', pageGroupMode === 'expanded');
+  if (compact) compact.setAttribute('aria-pressed', pageGroupMode === 'compact' ? 'true' : 'false');
+  if (expand) expand.setAttribute('aria-pressed', pageGroupMode === 'expanded' ? 'true' : 'false');
 }
 
 function setPageGroupMode(mode) {

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
@@ -21,6 +21,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 1rem;
     padding: 0.5rem 1rem;
     background: #1e293b;
     border-bottom: 1px solid #334155;
@@ -30,6 +31,8 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    min-width: 0;
+    flex: 1;
   }
   .top-bar-title {
     font-size: 0.85rem;
@@ -37,11 +40,52 @@
     color: #e2e8f0;
     white-space: nowrap;
   }
+  .portfolio-back {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 26px;
+    padding: 0 0.55rem;
+    border: 1px solid #334155;
+    border-radius: 4px;
+    background: #0f172a;
+    color: #cbd5e1;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: all 0.15s;
+  }
+  .portfolio-back:hover,
+  .portfolio-back:focus {
+    border-color: #818cf8;
+    color: #c7d2fe;
+    outline: none;
+  }
   .top-bar-context {
     font-size: 0.75rem;
     color: #818cf8;
     font-family: 'SF Mono', 'Fira Code', monospace;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+  .top-bar-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    flex: 0 1 auto;
+    min-width: 0;
+    margin-left: auto;
+  }
+  .top-bar-version-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    flex: 0 1 318px;
+    min-width: 210px;
   }
   .proto-select {
     background: #0f172a;
@@ -52,7 +96,8 @@
     font-size: 0.75rem;
     font-family: inherit;
     cursor: pointer;
-    min-width: 180px;
+    min-width: 0;
+    width: 100%;
   }
   .proto-select:focus { outline: none; border-color: #818cf8; }
   .page-nav {
@@ -113,6 +158,18 @@
   }
   .status-dot.connected .status-dot-circle { background: #22c55e; }
   .status-dot.connected .status-dot-label { color: #86efac; }
+  @media (max-width: 920px) {
+    .top-bar { gap: 0.65rem; }
+    .top-bar-actions { gap: 0.55rem; }
+    .top-bar-version-actions { flex-basis: 260px; }
+    .status-dot { display: none; }
+  }
+  @media (max-width: 760px) {
+    .top-bar-title { display: none; }
+    .top-bar-context { font-size: 0.7rem; }
+    .top-bar-version-actions { flex-basis: 210px; min-width: 180px; }
+    .viewport-pill { padding: 0.2rem 0.4rem; }
+  }
 
   /* Sidebar toggle (lives in top-bar) */
   .sidebar-toggle {
@@ -462,52 +519,6 @@
     line-height: 1.6;
   }
 
-  /* Prompt bar */
-  .prompt-bar {
-    border-top: 1px solid #1e293b;
-    padding: 0.65rem 1rem;
-    background: #0f172a;
-    display: flex;
-    gap: 0.5rem;
-    align-items: start;
-    flex-shrink: 0;
-  }
-  .prompt-text {
-    flex: 1;
-    background: #1e293b;
-    border: 1px solid #334155;
-    border-radius: 6px;
-    padding: 0.5rem 0.75rem;
-    font-size: 0.8rem;
-    color: #94a3b8;
-    min-height: 42px;
-    font-family: inherit;
-    line-height: 1.5;
-    resize: none;
-    overflow-y: auto;
-    max-height: 80px;
-  }
-  .prompt-text:focus { outline: none; border-color: #818cf8; color: #e2e8f0; }
-  .prompt-buttons {
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-    flex-shrink: 0;
-  }
-  .btn-copy {
-    background: #1e293b;
-    color: #94a3b8;
-    border: 1px solid #334155;
-    border-radius: 6px;
-    padding: 0.4rem 0.75rem;
-    font-size: 0.75rem;
-    cursor: pointer;
-    transition: all 0.15s;
-    font-family: inherit;
-  }
-  .btn-copy:hover { border-color: #818cf8; color: #c7d2fe; }
-  .btn-copy.copied { border-color: #22c55e; color: #86efac; }
-
   /* Compare mode */
   .compare-header {
     display: flex;
@@ -590,16 +601,19 @@
   <div class="top-bar-left">
     <button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()" title="Toggle sidebar" aria-label="Toggle sidebar">&#9776;</button>
     <span class="top-bar-title">Tinker Factory</span>
+    <a class="portfolio-back" href="/factory" title="Back to factory" aria-label="Back to Factory">&larr; Factory</a>
     <span class="top-bar-context" id="top-bar-context"></span>
-    <div class="page-nav">
-      <button class="page-nav-btn" id="page-prev" onclick="goToAdjacentPage(-1)" title="Previous page" aria-label="Previous page">&larr;</button>
-      <button class="page-nav-btn" id="page-next" onclick="goToAdjacentPage(1)" title="Next page" aria-label="Next page">&rarr;</button>
-    </div>
-    <select class="proto-select" id="proto-select" onchange="selectProtoFromDropdown(this.value)">
-      <option value="">Loading slots...</option>
-    </select>
   </div>
-  <div style="display:flex;align-items:center;gap:0.75rem;">
+  <div class="top-bar-actions">
+    <div class="top-bar-version-actions">
+      <div class="page-nav">
+        <button class="page-nav-btn" id="page-prev" onclick="goToAdjacentPage(-1)" title="Previous page" aria-label="Previous page">&larr;</button>
+        <button class="page-nav-btn" id="page-next" onclick="goToAdjacentPage(1)" title="Next page" aria-label="Next page">&rarr;</button>
+      </div>
+      <select class="proto-select" id="proto-select" onchange="selectProtoFromDropdown(this.value)">
+        <option value="">Loading slots...</option>
+      </select>
+    </div>
     <div class="viewport-pills" id="viewport-pills">
       <button class="viewport-pill active" data-viewport="desktop" onclick="setViewport('desktop')">Desktop</button>
       <button class="viewport-pill" data-viewport="tablet" onclick="setViewport('tablet')">Tablet</button>
@@ -666,14 +680,6 @@
         <p id="preview-placeholder-msg">Loading prototypes...</p>
       </div>
     </div>
-  </div>
-</div>
-
-<!-- Prompt Bar -->
-<div class="prompt-bar">
-  <textarea class="prompt-text" id="prompt-text" rows="2" placeholder="Describe what you want to iterate on..."></textarea>
-  <div class="prompt-buttons">
-    <button class="btn-copy" id="btn-copy" onclick="copyPrompt()">Copy</button>
   </div>
 </div>
 
@@ -913,20 +919,6 @@ function updateTopBarContext() {
   } else {
     ctx.textContent = '';
   }
-}
-
-// --- Copy prompt ---
-function copyPrompt() {
-  var text = document.getElementById('prompt-text').value;
-  navigator.clipboard.writeText(text).then(function() {
-    var btn = document.getElementById('btn-copy');
-    btn.textContent = 'Copied!';
-    btn.classList.add('copied');
-    setTimeout(function() {
-      btn.textContent = 'Copy';
-      btn.classList.remove('copied');
-    }, 1500);
-  });
 }
 
 // --- Prototype preview ---
@@ -1251,6 +1243,7 @@ function updateStylePrompt() {
   }
 
   var promptEl = document.getElementById('prompt-text');
+  if (!promptEl) return;
   var segments = [];
   if (selectedOption) segments.push('Selected: ' + selectedOption);
   if (parts.length > 0) segments.push('Iterate with ' + parts.join(', ') + '.');

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/portfolio.html
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/portfolio.html
@@ -31,11 +31,39 @@
     color: #64748b;
     margin-left: 0.5rem;
   }
+  .top-bar-subtitle.active-scope {
+    color: #94a3b8;
+    font-weight: 600;
+  }
   .toolbar {
     display: grid;
-    grid-template-columns: minmax(220px, 1fr) 180px 160px;
+    grid-template-columns: minmax(220px, 1fr) auto 180px 160px;
     gap: 0.6rem;
     padding: 1rem 1.25rem 0;
+  }
+  .all-pages-btn {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    min-height: 37px;
+    padding: 0 0.75rem;
+    border: 1px solid #334155;
+    border-radius: 7px;
+    background: #0f172a;
+    color: #c7d2fe;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.76rem;
+    font-weight: 650;
+    white-space: nowrap;
+  }
+  .all-pages-btn:hover,
+  .all-pages-btn:focus {
+    border-color: #818cf8;
+    outline: none;
+  }
+  .all-pages-btn.visible {
+    display: inline-flex;
   }
   .toolbar input,
   .toolbar select {
@@ -62,9 +90,58 @@
 
   .grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
     gap: 1rem;
     padding: 1.25rem;
+  }
+  .grouped {
+    display: grid;
+    gap: 1.35rem;
+    padding: 1.25rem;
+  }
+  .group-section {
+    display: grid;
+    gap: 0.75rem;
+  }
+  .group-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0 0.1rem 0.15rem;
+  }
+  .group-title {
+    color: #e2e8f0;
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .group-count {
+    color: #94a3b8;
+    font-size: 0.76rem;
+    font-weight: 600;
+  }
+  .group-view {
+    background: transparent;
+    border: 1px solid #334155;
+    border-radius: 5px;
+    color: #c7d2fe;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.72rem;
+    font-weight: 650;
+    padding: 0.24rem 0.55rem;
+  }
+  .group-view:hover,
+  .group-view:focus {
+    border-color: #818cf8;
+    outline: none;
+  }
+  .group-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+    gap: 1rem;
   }
 
   .card {
@@ -83,9 +160,9 @@
   .card-thumb {
     position: relative;
     width: 100%;
-    height: 180px;
+    min-height: 168px;
     overflow: hidden;
-    background: #fff;
+    background: #020617;
   }
   .card-thumb iframe {
     position: absolute;
@@ -100,28 +177,30 @@
   }
 
   .card-body {
-    padding: 0.75rem 0.85rem;
+    padding: 0.85rem 0.95rem;
   }
   .card-name {
-    font-size: 0.82rem;
+    font-size: 0.92rem;
     font-weight: 600;
     color: #e2e8f0;
     font-family: 'SF Mono', 'Fira Code', monospace;
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.55rem;
+    line-height: 1.25;
   }
   .card-meta {
     display: flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0.45rem;
     flex-wrap: wrap;
   }
 
   .badge {
-    font-size: 0.62rem;
-    padding: 0.15rem 0.45rem;
+    font-size: 0.72rem;
+    padding: 0.18rem 0.5rem;
     border-radius: 9999px;
-    font-weight: 500;
+    font-weight: 600;
     white-space: nowrap;
+    line-height: 1.15;
   }
   .badge-versions {
     background: #1e1b4b;
@@ -139,8 +218,9 @@
     border: 1px solid #115e59;
   }
   .badge-time {
-    color: #475569;
-    font-size: 0.62rem;
+    color: #94a3b8;
+    font-size: 0.72rem;
+    font-weight: 600;
     margin-left: auto;
   }
 
@@ -167,6 +247,7 @@
 
 <div class="toolbar">
   <input id="page-search" type="search" placeholder="Search pages, groups, selected options..." oninput="updateFilters()" />
+  <button class="all-pages-btn" id="all-pages-btn" type="button" onclick="clearCategory()">All pages</button>
   <select id="category-filter" onchange="updateFilters()">
     <option value="">All categories</option>
   </select>
@@ -180,6 +261,7 @@
 </div>
 
 <div class="grid" id="grid"></div>
+<div class="grouped" id="grouped" style="display:none;"></div>
 <div class="empty" id="empty" style="display:none;">
   <p>No pages yet.<br>Use the factory to brainstorm your first page.</p>
 </div>
@@ -214,6 +296,10 @@ function getPageTime(page) {
   return page && page.lastModified ? new Date(page.lastModified).getTime() : 0;
 }
 
+function getPageGroup(page) {
+  return page.group || 'Ungrouped';
+}
+
 function updateCategoryOptions(pages) {
   var select = document.getElementById('category-filter');
   var current = select.value;
@@ -240,6 +326,40 @@ function updateCategoryOptions(pages) {
   });
   select.value = seen[current] ? current : '';
   filters.category = select.value;
+}
+
+function hasCategoryOption(value) {
+  var select = document.getElementById('category-filter');
+  for (var i = 0; i < select.options.length; i++) {
+    if (select.options[i].value === value) return true;
+  }
+  return false;
+}
+
+function applyUrlFilters() {
+  var params = new URLSearchParams(window.location.search);
+  var category = params.get('category') || '';
+  var select = document.getElementById('category-filter');
+  select.value = category && hasCategoryOption(category) ? category : '';
+  filters.category = select.value;
+}
+
+function syncCategoryUrl(mode) {
+  var url = new URL(window.location.href);
+  if (filters.category) {
+    url.searchParams.set('category', filters.category);
+  } else {
+    url.searchParams.delete('category');
+  }
+  var method = mode === 'replace' ? 'replaceState' : 'pushState';
+  window.history[method]({}, '', url.pathname + url.search);
+}
+
+function clearCategory() {
+  document.getElementById('category-filter').value = '';
+  filters.category = '';
+  syncCategoryUrl('push');
+  renderCards(getFilteredPages());
 }
 
 function getFilteredPages() {
@@ -276,88 +396,211 @@ function updateFilters() {
   filters.query = document.getElementById('page-search').value;
   filters.category = document.getElementById('category-filter').value;
   filters.sort = document.getElementById('sort-select').value;
+  syncCategoryUrl('push');
   renderCards(getFilteredPages());
+}
+
+function selectCategory(group) {
+  document.getElementById('category-filter').value = group;
+  filters.category = group;
+  syncCategoryUrl('push');
+  renderCards(getFilteredPages());
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function updateHeader(pages) {
+  var title = document.querySelector('.top-bar-title');
+  var count = document.getElementById('page-count');
+  var allPagesBtn = document.getElementById('all-pages-btn');
+  var totalLabel = pages.length === 1 ? 'page' : 'pages';
+
+  if (filters.category) {
+    title.textContent = 'Factory / ' + filters.category;
+    count.textContent = pages.length + ' ' + totalLabel;
+    count.classList.add('active-scope');
+    allPagesBtn.classList.add('visible');
+  } else {
+    title.textContent = 'Factory Portfolio';
+    count.textContent = pages.length + ' of ' + allPages.length + (allPages.length === 1 ? ' page' : ' pages');
+    count.classList.remove('active-scope');
+    allPagesBtn.classList.remove('visible');
+  }
+}
+
+function isGroupedDefaultView() {
+  return !(filters.query || '').trim() && !filters.category && filters.sort === 'updated-desc';
+}
+
+function scaleThumbs() {
+  var thumbs = document.querySelectorAll('.card-thumb');
+  for (var i = 0; i < thumbs.length; i++) {
+    var thumb = thumbs[i];
+    var iframe = thumb.querySelector('iframe');
+    if (!iframe) continue;
+    var scale = thumb.clientWidth / 1280;
+    thumb.style.height = Math.max(168, Math.round(720 * scale)) + 'px';
+    iframe.style.transform = 'scale(' + scale + ')';
+  }
+}
+
+window.addEventListener('resize', scaleThumbs);
+
+function scheduleThumbScale() {
+  requestAnimationFrame(scaleThumbs);
+}
+
+function createCard(p) {
+  var card = document.createElement('div');
+  card.className = 'card';
+  card.onclick = function() { window.location.href = buildFactoryHref(p.page); };
+
+  var thumb = document.createElement('div');
+  thumb.className = 'card-thumb';
+  if (p.latestFile) {
+    var iframe = document.createElement('iframe');
+    iframe.src = '/prototype?file=' + encodeURIComponent(p.latestFile);
+    iframe.setAttribute('loading', 'lazy');
+    iframe.setAttribute('tabindex', '-1');
+    thumb.appendChild(iframe);
+  }
+  card.appendChild(thumb);
+
+  var body = document.createElement('div');
+  body.className = 'card-body';
+
+  var name = document.createElement('div');
+  name.className = 'card-name';
+  name.textContent = p.name || p.page;
+  body.appendChild(name);
+
+  var meta = document.createElement('div');
+  meta.className = 'card-meta';
+
+  var vBadge = document.createElement('span');
+  vBadge.className = 'badge badge-versions';
+  vBadge.textContent = p.versions + (p.versions === 1 ? ' version' : ' versions');
+  meta.appendChild(vBadge);
+
+  if (p.group && p.group !== 'Ungrouped') {
+    var gBadge = document.createElement('span');
+    gBadge.className = 'badge badge-group';
+    gBadge.textContent = p.group;
+    meta.appendChild(gBadge);
+  }
+
+  if (p.selectedOption) {
+    var sBadge = document.createElement('span');
+    sBadge.className = 'badge badge-selected';
+    sBadge.textContent = p.selectedOption;
+    meta.appendChild(sBadge);
+  }
+
+  if (p.lastModified) {
+    var time = document.createElement('span');
+    time.className = 'badge-time';
+    time.textContent = relativeTime(p.lastModified);
+    meta.appendChild(time);
+  }
+
+  body.appendChild(meta);
+  card.appendChild(body);
+  return card;
+}
+
+function renderFlatCards(grid, pages) {
+  pages.forEach(function(p) {
+    grid.appendChild(createCard(p));
+  });
+}
+
+function renderGroupedCards(groupedEl, pages) {
+  var groups = {};
+  pages.forEach(function(page) {
+    var group = getPageGroup(page);
+    if (!groups[group]) groups[group] = [];
+    groups[group].push(page);
+  });
+
+  var groupNames = Object.keys(groups).sort(function(a, b) {
+    return getPageTime(groups[b][0]) - getPageTime(groups[a][0]) || compareText(a, b);
+  });
+
+  groupNames.forEach(function(group) {
+    var section = document.createElement('section');
+    section.className = 'group-section';
+
+    var header = document.createElement('div');
+    header.className = 'group-header';
+
+    var titleWrap = document.createElement('div');
+    var title = document.createElement('div');
+    title.className = 'group-title';
+    title.textContent = group;
+    var groupCount = document.createElement('div');
+    groupCount.className = 'group-count';
+    groupCount.textContent = groups[group].length + (groups[group].length === 1 ? ' page' : ' pages');
+    titleWrap.appendChild(title);
+    titleWrap.appendChild(groupCount);
+    header.appendChild(titleWrap);
+
+    if (groups[group].length > 3) {
+      var viewButton = document.createElement('button');
+      viewButton.className = 'group-view';
+      viewButton.type = 'button';
+      viewButton.textContent = 'View all';
+      viewButton.onclick = function() {
+        selectCategory(group);
+      };
+      header.appendChild(viewButton);
+    }
+
+    section.appendChild(header);
+
+    var groupGrid = document.createElement('div');
+    groupGrid.className = 'group-grid';
+    groups[group].slice(0, 3).forEach(function(p) {
+      groupGrid.appendChild(createCard(p));
+    });
+    section.appendChild(groupGrid);
+    groupedEl.appendChild(section);
+  });
 }
 
 function renderCards(pages) {
   var grid = document.getElementById('grid');
+  var groupedEl = document.getElementById('grouped');
   var empty = document.getElementById('empty');
   var count = document.getElementById('page-count');
   grid.innerHTML = '';
+  groupedEl.innerHTML = '';
 
   if (!pages || pages.length === 0) {
     grid.style.display = 'none';
+    groupedEl.style.display = 'none';
     empty.style.display = '';
-    count.textContent = allPages.length ? '0 of ' + allPages.length + ' pages' : '';
+    count.textContent = allPages.length
+      ? (filters.category ? filters.category + ' · 0 pages' : '0 of ' + allPages.length + ' pages')
+      : '';
     empty.querySelector('p').innerHTML = allPages.length
       ? 'No pages match the current filters.'
       : 'No pages yet.<br>Use the factory to brainstorm your first page.';
     return;
   }
 
-  grid.style.display = 'grid';
   empty.style.display = 'none';
-  count.textContent = pages.length + ' of ' + allPages.length + (allPages.length === 1 ? ' page' : ' pages');
+  updateHeader(pages);
 
-  pages.forEach(function(p) {
-    var card = document.createElement('div');
-    card.className = 'card';
-    card.onclick = function() { window.location.href = buildFactoryHref(p.page); };
+  if (isGroupedDefaultView()) {
+    grid.style.display = 'none';
+    groupedEl.style.display = 'grid';
+    renderGroupedCards(groupedEl, pages);
+  } else {
+    groupedEl.style.display = 'none';
+    grid.style.display = 'grid';
+    renderFlatCards(grid, pages);
+  }
 
-    // Thumbnail
-    var thumb = document.createElement('div');
-    thumb.className = 'card-thumb';
-    if (p.latestFile) {
-      var iframe = document.createElement('iframe');
-      iframe.src = '/prototype?file=' + encodeURIComponent(p.latestFile);
-      iframe.setAttribute('loading', 'lazy');
-      iframe.setAttribute('tabindex', '-1');
-      thumb.appendChild(iframe);
-    }
-    card.appendChild(thumb);
-
-    // Body
-    var body = document.createElement('div');
-    body.className = 'card-body';
-
-    var name = document.createElement('div');
-    name.className = 'card-name';
-    name.textContent = p.name || p.page;
-    body.appendChild(name);
-
-    var meta = document.createElement('div');
-    meta.className = 'card-meta';
-
-    var vBadge = document.createElement('span');
-    vBadge.className = 'badge badge-versions';
-    vBadge.textContent = p.versions + (p.versions === 1 ? ' version' : ' versions');
-    meta.appendChild(vBadge);
-
-    if (p.group && p.group !== 'Ungrouped') {
-      var gBadge = document.createElement('span');
-      gBadge.className = 'badge badge-group';
-      gBadge.textContent = p.group;
-      meta.appendChild(gBadge);
-    }
-
-    if (p.selectedOption) {
-      var sBadge = document.createElement('span');
-      sBadge.className = 'badge badge-selected';
-      sBadge.textContent = p.selectedOption;
-      meta.appendChild(sBadge);
-    }
-
-    if (p.lastModified) {
-      var time = document.createElement('span');
-      time.className = 'badge-time';
-      time.textContent = relativeTime(p.lastModified);
-      meta.appendChild(time);
-    }
-
-    body.appendChild(meta);
-    card.appendChild(body);
-    grid.appendChild(card);
-  });
+  scheduleThumbScale();
 }
 
 fetch('/api/page-status')
@@ -365,12 +608,19 @@ fetch('/api/page-status')
   .then(function(pages) {
     allPages = pages || [];
     updateCategoryOptions(allPages);
+    applyUrlFilters();
+    syncCategoryUrl('replace');
     renderCards(getFilteredPages());
   })
   .catch(function(err) {
     document.getElementById('empty').style.display = '';
     document.getElementById('empty').querySelector('p').textContent = 'Failed to load: ' + err.message;
   });
+
+window.addEventListener('popstate', function() {
+  applyUrlFilters();
+  renderCards(getFilteredPages());
+});
 </script>
 </body>
 </html>

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
@@ -470,13 +470,8 @@ function servePrototype(res, filePath) {
 function serveBrainstorm(res) {
   const file = newestHtml();
   if (!file) {
-    res.writeHead(200, { "Content-Type": "text/html" });
-    res.end(
-      frameTemplate.replace(
-        "{{CONTENT}}",
-        '<div class="waiting">Waiting for content...</div>'
-      )
-    );
+    res.writeHead(302, { Location: "/factory" });
+    res.end();
     return;
   }
   const content = fs.readFileSync(path.join(screenDir, file), "utf8");

--- a/plugins/ctx/.claude-plugin/plugin.json
+++ b/plugins/ctx/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctx",
   "description": "Personal development toolkit built on context economy — brainstorm, plan, execute, ship, QA. Every skill optimizes for minimal token spend with maximum signal.",
-  "version": "0.2.9.6",
+  "version": "0.2.9.7",
   "author": {
     "name": "Garo Nazarian"
   }

--- a/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
@@ -299,20 +299,30 @@
   }
   .page-action-row {
     display: grid;
-    grid-template-columns: 1fr 1fr;
     gap: 0.35rem;
+  }
+  .page-mode-toggle {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    padding: 0.15rem;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    background: #0a0e17;
   }
   .page-tool-btn {
     background: #1e293b;
     color: #94a3b8;
-    border: 1px solid #334155;
-    border-radius: 5px;
+    border: 1px solid transparent;
+    border-radius: 4px;
     padding: 0.32rem 0.5rem;
     font-size: 0.68rem;
     cursor: pointer;
     font-family: inherit;
     transition: all 0.15s;
     white-space: nowrap;
+  }
+  .page-mode-toggle .page-tool-btn {
+    background: transparent;
   }
   .page-tool-btn:hover,
   .page-tool-btn.active {
@@ -324,7 +334,8 @@
     cursor: wait;
   }
   #page-rescan {
-    grid-column: 1 / -1;
+    width: 100%;
+    border-color: #334155;
   }
   .page-results {
     font-size: 0.65rem;
@@ -695,8 +706,10 @@
           </select>
         </div>
         <div class="page-action-row">
-          <button class="page-tool-btn active" id="page-compact" type="button" onclick="setPageGroupMode('compact')">Compact</button>
-          <button class="page-tool-btn" id="page-expand" type="button" onclick="setPageGroupMode('expanded')">Expand</button>
+          <div class="page-mode-toggle" role="group" aria-label="Page group display mode">
+            <button class="page-tool-btn active" id="page-compact" type="button" onclick="setPageGroupMode('compact')" aria-pressed="true">Compact</button>
+            <button class="page-tool-btn" id="page-expand" type="button" onclick="setPageGroupMode('expanded')" aria-pressed="false">Expand</button>
+          </div>
           <button class="page-tool-btn btn-rescan" id="page-rescan" type="button" onclick="triggerRescan()">Re-scan project</button>
         </div>
         <div class="page-versions" id="versions-section">
@@ -893,6 +906,8 @@ function updatePageGroupModeButtons() {
   var expand = document.getElementById('page-expand');
   if (compact) compact.classList.toggle('active', pageGroupMode === 'compact');
   if (expand) expand.classList.toggle('active', pageGroupMode === 'expanded');
+  if (compact) compact.setAttribute('aria-pressed', pageGroupMode === 'compact' ? 'true' : 'false');
+  if (expand) expand.setAttribute('aria-pressed', pageGroupMode === 'expanded' ? 'true' : 'false');
 }
 
 function setPageGroupMode(mode) {

--- a/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
@@ -21,6 +21,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 1rem;
     padding: 0.5rem 1rem;
     background: #1e293b;
     border-bottom: 1px solid #334155;
@@ -30,6 +31,8 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    min-width: 0;
+    flex: 1;
   }
   .top-bar-title {
     font-size: 0.85rem;
@@ -37,11 +40,52 @@
     color: #e2e8f0;
     white-space: nowrap;
   }
+  .portfolio-back {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 26px;
+    padding: 0 0.55rem;
+    border: 1px solid #334155;
+    border-radius: 4px;
+    background: #0f172a;
+    color: #cbd5e1;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: all 0.15s;
+  }
+  .portfolio-back:hover,
+  .portfolio-back:focus {
+    border-color: #818cf8;
+    color: #c7d2fe;
+    outline: none;
+  }
   .top-bar-context {
     font-size: 0.75rem;
     color: #818cf8;
     font-family: 'SF Mono', 'Fira Code', monospace;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+  .top-bar-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    flex: 0 1 auto;
+    min-width: 0;
+    margin-left: auto;
+  }
+  .top-bar-version-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    flex: 0 1 318px;
+    min-width: 210px;
   }
   .proto-select {
     background: #0f172a;
@@ -52,7 +96,8 @@
     font-size: 0.75rem;
     font-family: inherit;
     cursor: pointer;
-    min-width: 180px;
+    min-width: 0;
+    width: 100%;
   }
   .proto-select:focus { outline: none; border-color: #818cf8; }
   .page-nav {
@@ -113,6 +158,18 @@
   }
   .status-dot.connected .status-dot-circle { background: #22c55e; }
   .status-dot.connected .status-dot-label { color: #86efac; }
+  @media (max-width: 920px) {
+    .top-bar { gap: 0.65rem; }
+    .top-bar-actions { gap: 0.55rem; }
+    .top-bar-version-actions { flex-basis: 260px; }
+    .status-dot { display: none; }
+  }
+  @media (max-width: 760px) {
+    .top-bar-title { display: none; }
+    .top-bar-context { font-size: 0.7rem; }
+    .top-bar-version-actions { flex-basis: 210px; min-width: 180px; }
+    .viewport-pill { padding: 0.2rem 0.4rem; }
+  }
 
   /* Sidebar toggle (lives in top-bar) */
   .sidebar-toggle {
@@ -462,52 +519,6 @@
     line-height: 1.6;
   }
 
-  /* Prompt bar */
-  .prompt-bar {
-    border-top: 1px solid #1e293b;
-    padding: 0.65rem 1rem;
-    background: #0f172a;
-    display: flex;
-    gap: 0.5rem;
-    align-items: start;
-    flex-shrink: 0;
-  }
-  .prompt-text {
-    flex: 1;
-    background: #1e293b;
-    border: 1px solid #334155;
-    border-radius: 6px;
-    padding: 0.5rem 0.75rem;
-    font-size: 0.8rem;
-    color: #94a3b8;
-    min-height: 42px;
-    font-family: inherit;
-    line-height: 1.5;
-    resize: none;
-    overflow-y: auto;
-    max-height: 80px;
-  }
-  .prompt-text:focus { outline: none; border-color: #818cf8; color: #e2e8f0; }
-  .prompt-buttons {
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-    flex-shrink: 0;
-  }
-  .btn-copy {
-    background: #1e293b;
-    color: #94a3b8;
-    border: 1px solid #334155;
-    border-radius: 6px;
-    padding: 0.4rem 0.75rem;
-    font-size: 0.75rem;
-    cursor: pointer;
-    transition: all 0.15s;
-    font-family: inherit;
-  }
-  .btn-copy:hover { border-color: #818cf8; color: #c7d2fe; }
-  .btn-copy.copied { border-color: #22c55e; color: #86efac; }
-
   /* Compare mode */
   .compare-header {
     display: flex;
@@ -590,16 +601,19 @@
   <div class="top-bar-left">
     <button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()" title="Toggle sidebar" aria-label="Toggle sidebar">&#9776;</button>
     <span class="top-bar-title">Tinker Factory</span>
+    <a class="portfolio-back" href="/factory" title="Back to factory" aria-label="Back to Factory">&larr; Factory</a>
     <span class="top-bar-context" id="top-bar-context"></span>
-    <div class="page-nav">
-      <button class="page-nav-btn" id="page-prev" onclick="goToAdjacentPage(-1)" title="Previous page" aria-label="Previous page">&larr;</button>
-      <button class="page-nav-btn" id="page-next" onclick="goToAdjacentPage(1)" title="Next page" aria-label="Next page">&rarr;</button>
-    </div>
-    <select class="proto-select" id="proto-select" onchange="selectProtoFromDropdown(this.value)">
-      <option value="">Loading slots...</option>
-    </select>
   </div>
-  <div style="display:flex;align-items:center;gap:0.75rem;">
+  <div class="top-bar-actions">
+    <div class="top-bar-version-actions">
+      <div class="page-nav">
+        <button class="page-nav-btn" id="page-prev" onclick="goToAdjacentPage(-1)" title="Previous page" aria-label="Previous page">&larr;</button>
+        <button class="page-nav-btn" id="page-next" onclick="goToAdjacentPage(1)" title="Next page" aria-label="Next page">&rarr;</button>
+      </div>
+      <select class="proto-select" id="proto-select" onchange="selectProtoFromDropdown(this.value)">
+        <option value="">Loading slots...</option>
+      </select>
+    </div>
     <div class="viewport-pills" id="viewport-pills">
       <button class="viewport-pill active" data-viewport="desktop" onclick="setViewport('desktop')">Desktop</button>
       <button class="viewport-pill" data-viewport="tablet" onclick="setViewport('tablet')">Tablet</button>
@@ -666,14 +680,6 @@
         <p id="preview-placeholder-msg">Loading prototypes...</p>
       </div>
     </div>
-  </div>
-</div>
-
-<!-- Prompt Bar -->
-<div class="prompt-bar">
-  <textarea class="prompt-text" id="prompt-text" rows="2" placeholder="Describe what you want to iterate on..."></textarea>
-  <div class="prompt-buttons">
-    <button class="btn-copy" id="btn-copy" onclick="copyPrompt()">Copy</button>
   </div>
 </div>
 
@@ -913,20 +919,6 @@ function updateTopBarContext() {
   } else {
     ctx.textContent = '';
   }
-}
-
-// --- Copy prompt ---
-function copyPrompt() {
-  var text = document.getElementById('prompt-text').value;
-  navigator.clipboard.writeText(text).then(function() {
-    var btn = document.getElementById('btn-copy');
-    btn.textContent = 'Copied!';
-    btn.classList.add('copied');
-    setTimeout(function() {
-      btn.textContent = 'Copy';
-      btn.classList.remove('copied');
-    }, 1500);
-  });
 }
 
 // --- Prototype preview ---
@@ -1251,6 +1243,7 @@ function updateStylePrompt() {
   }
 
   var promptEl = document.getElementById('prompt-text');
+  if (!promptEl) return;
   var segments = [];
   if (selectedOption) segments.push('Selected: ' + selectedOption);
   if (parts.length > 0) segments.push('Iterate with ' + parts.join(', ') + '.');

--- a/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
@@ -297,11 +297,57 @@
     grid-template-columns: 1fr 1fr;
     gap: 0.35rem;
   }
+  .page-action-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.35rem;
+  }
+  .page-tool-btn {
+    background: #1e293b;
+    color: #94a3b8;
+    border: 1px solid #334155;
+    border-radius: 5px;
+    padding: 0.32rem 0.5rem;
+    font-size: 0.68rem;
+    cursor: pointer;
+    font-family: inherit;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+  .page-tool-btn:hover,
+  .page-tool-btn.active {
+    border-color: #818cf8;
+    color: #c7d2fe;
+  }
+  .page-tool-btn:disabled {
+    opacity: 0.5;
+    cursor: wait;
+  }
+  #page-rescan {
+    grid-column: 1 / -1;
+  }
   .page-results {
     font-size: 0.65rem;
     color: #64748b;
     margin: -0.15rem 0 0.45rem;
     font-family: 'SF Mono', 'Fira Code', monospace;
+  }
+  .page-versions {
+    display: none;
+    padding: 0.45rem 0;
+    border-top: 1px solid #1e293b;
+    border-bottom: 1px solid #1e293b;
+  }
+  .page-versions.visible {
+    display: block;
+  }
+  .page-versions-label {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: #64748b;
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
   .page-row {
     display: flex;
@@ -648,17 +694,20 @@
             <option value="category-asc">Category A-Z</option>
           </select>
         </div>
+        <div class="page-action-row">
+          <button class="page-tool-btn active" id="page-compact" type="button" onclick="setPageGroupMode('compact')">Compact</button>
+          <button class="page-tool-btn" id="page-expand" type="button" onclick="setPageGroupMode('expanded')">Expand</button>
+          <button class="page-tool-btn btn-rescan" id="page-rescan" type="button" onclick="triggerRescan()">Re-scan project</button>
+        </div>
+        <div class="page-versions" id="versions-section">
+          <span class="page-versions-label">Versions</span>
+          <div class="version-pills" id="version-pills">
+            <!-- Populated by JS -->
+          </div>
+        </div>
         <div class="page-results" id="page-results"></div>
       </div>
       <div id="pages-list">
-        <!-- Populated by JS -->
-      </div>
-    </div>
-
-    <!-- Versions section (shown when a page is active) -->
-    <div class="controls-section" id="versions-section" style="display:none;">
-      <div class="controls-section-title">Versions</div>
-      <div class="version-pills" id="version-pills">
         <!-- Populated by JS -->
       </div>
     </div>
@@ -693,6 +742,7 @@ var compareMode = false;
 var compareItems = [];
 var currentViewport = 'desktop';
 var expandedGroups = {};
+var pageGroupMode = 'compact';
 var previewFileBase = '/page?file=';
 var pageFilters = { query: '', category: '', sort: 'updated-desc' };
 
@@ -831,6 +881,32 @@ function updatePageFilters() {
   pageFilters.sort = sort ? sort.value : 'updated-desc';
   renderPagesList();
   updatePageNavButtons();
+}
+
+function getActiveGroupName() {
+  var activeSlot = findSlot(activePage);
+  return getGroupName(activeSlot);
+}
+
+function updatePageGroupModeButtons() {
+  var compact = document.getElementById('page-compact');
+  var expand = document.getElementById('page-expand');
+  if (compact) compact.classList.toggle('active', pageGroupMode === 'compact');
+  if (expand) expand.classList.toggle('active', pageGroupMode === 'expanded');
+}
+
+function setPageGroupMode(mode) {
+  pageGroupMode = mode === 'expanded' ? 'expanded' : 'compact';
+  var activeGroup = getActiveGroupName();
+  var groups = {};
+  allSlots.forEach(function(slotData) {
+    groups[getGroupName(slotData)] = true;
+  });
+  Object.keys(groups).forEach(function(groupName) {
+    expandedGroups[groupName] = pageGroupMode === 'expanded' || groupName === activeGroup;
+  });
+  updatePageGroupModeButtons();
+  renderPagesList();
 }
 
 function updatePageNavButtons() {
@@ -1007,7 +1083,9 @@ function renderPagesList() {
     if (!grouped[groupName]) {
       grouped[groupName] = [];
       order.push(groupName);
-      if (expandedGroups[groupName] == null) expandedGroups[groupName] = true;
+      if (expandedGroups[groupName] == null) {
+        expandedGroups[groupName] = pageGroupMode === 'expanded' || groupName === getActiveGroupName();
+      }
     }
     grouped[groupName].push(slotData);
   });
@@ -1071,10 +1149,17 @@ function activatePage(slotName, autoSelectLatest) {
   if (!slotData) return;
 
   activePage = slotName;
+  if (pageGroupMode === 'compact') {
+    var activeGroup = getGroupName(slotData);
+    Object.keys(expandedGroups).forEach(function(groupName) {
+      expandedGroups[groupName] = groupName === activeGroup;
+    });
+    expandedGroups[activeGroup] = true;
+  }
   renderPagesList();
 
   var versionsSection = document.getElementById('versions-section');
-  versionsSection.style.display = '';
+  versionsSection.classList.add('visible');
   renderVersionPills(slotName);
   renderProtoSelect();
   updatePageNavButtons();
@@ -1134,7 +1219,7 @@ function renderSlots(slots) {
   activeVersion = null;
 
   clearChildren(protoSelect);
-  versionsSection.style.display = 'none';
+  versionsSection.classList.remove('visible');
   clearChildren(document.getElementById('version-pills'));
   renderPagesList();
 
@@ -1492,8 +1577,7 @@ function loadStyleProfile() {
 }
 
 function triggerRescan() {
-  var container = document.getElementById('style-controls-content');
-  var btns = container.querySelectorAll('.btn-rescan');
+  var btns = document.querySelectorAll('.btn-rescan');
   btns.forEach(function(b) { b.disabled = true; b.textContent = 'Scanning...'; });
 
   fetch('/api/scan', { method: 'POST' })

--- a/plugins/ctx/skills/ctx-brainstorm/factory/portfolio.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/portfolio.html
@@ -31,11 +31,39 @@
     color: #64748b;
     margin-left: 0.5rem;
   }
+  .top-bar-subtitle.active-scope {
+    color: #94a3b8;
+    font-weight: 600;
+  }
   .toolbar {
     display: grid;
-    grid-template-columns: minmax(220px, 1fr) 180px 160px;
+    grid-template-columns: minmax(220px, 1fr) auto 180px 160px;
     gap: 0.6rem;
     padding: 1rem 1.25rem 0;
+  }
+  .all-pages-btn {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    min-height: 37px;
+    padding: 0 0.75rem;
+    border: 1px solid #334155;
+    border-radius: 7px;
+    background: #0f172a;
+    color: #c7d2fe;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.76rem;
+    font-weight: 650;
+    white-space: nowrap;
+  }
+  .all-pages-btn:hover,
+  .all-pages-btn:focus {
+    border-color: #818cf8;
+    outline: none;
+  }
+  .all-pages-btn.visible {
+    display: inline-flex;
   }
   .toolbar input,
   .toolbar select {
@@ -62,9 +90,58 @@
 
   .grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
     gap: 1rem;
     padding: 1.25rem;
+  }
+  .grouped {
+    display: grid;
+    gap: 1.35rem;
+    padding: 1.25rem;
+  }
+  .group-section {
+    display: grid;
+    gap: 0.75rem;
+  }
+  .group-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0 0.1rem 0.15rem;
+  }
+  .group-title {
+    color: #e2e8f0;
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .group-count {
+    color: #94a3b8;
+    font-size: 0.76rem;
+    font-weight: 600;
+  }
+  .group-view {
+    background: transparent;
+    border: 1px solid #334155;
+    border-radius: 5px;
+    color: #c7d2fe;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.72rem;
+    font-weight: 650;
+    padding: 0.24rem 0.55rem;
+  }
+  .group-view:hover,
+  .group-view:focus {
+    border-color: #818cf8;
+    outline: none;
+  }
+  .group-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+    gap: 1rem;
   }
 
   .card {
@@ -83,9 +160,9 @@
   .card-thumb {
     position: relative;
     width: 100%;
-    height: 180px;
+    min-height: 168px;
     overflow: hidden;
-    background: #fff;
+    background: #020617;
   }
   .card-thumb iframe {
     position: absolute;
@@ -100,28 +177,30 @@
   }
 
   .card-body {
-    padding: 0.75rem 0.85rem;
+    padding: 0.85rem 0.95rem;
   }
   .card-name {
-    font-size: 0.82rem;
+    font-size: 0.92rem;
     font-weight: 600;
     color: #e2e8f0;
     font-family: 'SF Mono', 'Fira Code', monospace;
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.55rem;
+    line-height: 1.25;
   }
   .card-meta {
     display: flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0.45rem;
     flex-wrap: wrap;
   }
 
   .badge {
-    font-size: 0.62rem;
-    padding: 0.15rem 0.45rem;
+    font-size: 0.72rem;
+    padding: 0.18rem 0.5rem;
     border-radius: 9999px;
-    font-weight: 500;
+    font-weight: 600;
     white-space: nowrap;
+    line-height: 1.15;
   }
   .badge-versions {
     background: #1e1b4b;
@@ -139,8 +218,9 @@
     border: 1px solid #115e59;
   }
   .badge-time {
-    color: #475569;
-    font-size: 0.62rem;
+    color: #94a3b8;
+    font-size: 0.72rem;
+    font-weight: 600;
     margin-left: auto;
   }
 
@@ -167,6 +247,7 @@
 
 <div class="toolbar">
   <input id="page-search" type="search" placeholder="Search pages, groups, selected options..." oninput="updateFilters()" />
+  <button class="all-pages-btn" id="all-pages-btn" type="button" onclick="clearCategory()">All pages</button>
   <select id="category-filter" onchange="updateFilters()">
     <option value="">All categories</option>
   </select>
@@ -180,6 +261,7 @@
 </div>
 
 <div class="grid" id="grid"></div>
+<div class="grouped" id="grouped" style="display:none;"></div>
 <div class="empty" id="empty" style="display:none;">
   <p>No pages yet.<br>Use the factory to brainstorm your first page.</p>
 </div>
@@ -214,6 +296,10 @@ function getPageTime(page) {
   return page && page.lastModified ? new Date(page.lastModified).getTime() : 0;
 }
 
+function getPageGroup(page) {
+  return page.group || 'Ungrouped';
+}
+
 function updateCategoryOptions(pages) {
   var select = document.getElementById('category-filter');
   var current = select.value;
@@ -240,6 +326,40 @@ function updateCategoryOptions(pages) {
   });
   select.value = seen[current] ? current : '';
   filters.category = select.value;
+}
+
+function hasCategoryOption(value) {
+  var select = document.getElementById('category-filter');
+  for (var i = 0; i < select.options.length; i++) {
+    if (select.options[i].value === value) return true;
+  }
+  return false;
+}
+
+function applyUrlFilters() {
+  var params = new URLSearchParams(window.location.search);
+  var category = params.get('category') || '';
+  var select = document.getElementById('category-filter');
+  select.value = category && hasCategoryOption(category) ? category : '';
+  filters.category = select.value;
+}
+
+function syncCategoryUrl(mode) {
+  var url = new URL(window.location.href);
+  if (filters.category) {
+    url.searchParams.set('category', filters.category);
+  } else {
+    url.searchParams.delete('category');
+  }
+  var method = mode === 'replace' ? 'replaceState' : 'pushState';
+  window.history[method]({}, '', url.pathname + url.search);
+}
+
+function clearCategory() {
+  document.getElementById('category-filter').value = '';
+  filters.category = '';
+  syncCategoryUrl('push');
+  renderCards(getFilteredPages());
 }
 
 function getFilteredPages() {
@@ -276,88 +396,211 @@ function updateFilters() {
   filters.query = document.getElementById('page-search').value;
   filters.category = document.getElementById('category-filter').value;
   filters.sort = document.getElementById('sort-select').value;
+  syncCategoryUrl('push');
   renderCards(getFilteredPages());
+}
+
+function selectCategory(group) {
+  document.getElementById('category-filter').value = group;
+  filters.category = group;
+  syncCategoryUrl('push');
+  renderCards(getFilteredPages());
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function updateHeader(pages) {
+  var title = document.querySelector('.top-bar-title');
+  var count = document.getElementById('page-count');
+  var allPagesBtn = document.getElementById('all-pages-btn');
+  var totalLabel = pages.length === 1 ? 'page' : 'pages';
+
+  if (filters.category) {
+    title.textContent = 'Factory / ' + filters.category;
+    count.textContent = pages.length + ' ' + totalLabel;
+    count.classList.add('active-scope');
+    allPagesBtn.classList.add('visible');
+  } else {
+    title.textContent = 'Factory Portfolio';
+    count.textContent = pages.length + ' of ' + allPages.length + (allPages.length === 1 ? ' page' : ' pages');
+    count.classList.remove('active-scope');
+    allPagesBtn.classList.remove('visible');
+  }
+}
+
+function isGroupedDefaultView() {
+  return !(filters.query || '').trim() && !filters.category && filters.sort === 'updated-desc';
+}
+
+function scaleThumbs() {
+  var thumbs = document.querySelectorAll('.card-thumb');
+  for (var i = 0; i < thumbs.length; i++) {
+    var thumb = thumbs[i];
+    var iframe = thumb.querySelector('iframe');
+    if (!iframe) continue;
+    var scale = thumb.clientWidth / 1280;
+    thumb.style.height = Math.max(168, Math.round(720 * scale)) + 'px';
+    iframe.style.transform = 'scale(' + scale + ')';
+  }
+}
+
+window.addEventListener('resize', scaleThumbs);
+
+function scheduleThumbScale() {
+  requestAnimationFrame(scaleThumbs);
+}
+
+function createCard(p) {
+  var card = document.createElement('div');
+  card.className = 'card';
+  card.onclick = function() { window.location.href = buildFactoryHref(p.page); };
+
+  var thumb = document.createElement('div');
+  thumb.className = 'card-thumb';
+  if (p.latestFile) {
+    var iframe = document.createElement('iframe');
+    iframe.src = '/prototype?file=' + encodeURIComponent(p.latestFile);
+    iframe.setAttribute('loading', 'lazy');
+    iframe.setAttribute('tabindex', '-1');
+    thumb.appendChild(iframe);
+  }
+  card.appendChild(thumb);
+
+  var body = document.createElement('div');
+  body.className = 'card-body';
+
+  var name = document.createElement('div');
+  name.className = 'card-name';
+  name.textContent = p.name || p.page;
+  body.appendChild(name);
+
+  var meta = document.createElement('div');
+  meta.className = 'card-meta';
+
+  var vBadge = document.createElement('span');
+  vBadge.className = 'badge badge-versions';
+  vBadge.textContent = p.versions + (p.versions === 1 ? ' version' : ' versions');
+  meta.appendChild(vBadge);
+
+  if (p.group && p.group !== 'Ungrouped') {
+    var gBadge = document.createElement('span');
+    gBadge.className = 'badge badge-group';
+    gBadge.textContent = p.group;
+    meta.appendChild(gBadge);
+  }
+
+  if (p.selectedOption) {
+    var sBadge = document.createElement('span');
+    sBadge.className = 'badge badge-selected';
+    sBadge.textContent = p.selectedOption;
+    meta.appendChild(sBadge);
+  }
+
+  if (p.lastModified) {
+    var time = document.createElement('span');
+    time.className = 'badge-time';
+    time.textContent = relativeTime(p.lastModified);
+    meta.appendChild(time);
+  }
+
+  body.appendChild(meta);
+  card.appendChild(body);
+  return card;
+}
+
+function renderFlatCards(grid, pages) {
+  pages.forEach(function(p) {
+    grid.appendChild(createCard(p));
+  });
+}
+
+function renderGroupedCards(groupedEl, pages) {
+  var groups = {};
+  pages.forEach(function(page) {
+    var group = getPageGroup(page);
+    if (!groups[group]) groups[group] = [];
+    groups[group].push(page);
+  });
+
+  var groupNames = Object.keys(groups).sort(function(a, b) {
+    return getPageTime(groups[b][0]) - getPageTime(groups[a][0]) || compareText(a, b);
+  });
+
+  groupNames.forEach(function(group) {
+    var section = document.createElement('section');
+    section.className = 'group-section';
+
+    var header = document.createElement('div');
+    header.className = 'group-header';
+
+    var titleWrap = document.createElement('div');
+    var title = document.createElement('div');
+    title.className = 'group-title';
+    title.textContent = group;
+    var groupCount = document.createElement('div');
+    groupCount.className = 'group-count';
+    groupCount.textContent = groups[group].length + (groups[group].length === 1 ? ' page' : ' pages');
+    titleWrap.appendChild(title);
+    titleWrap.appendChild(groupCount);
+    header.appendChild(titleWrap);
+
+    if (groups[group].length > 3) {
+      var viewButton = document.createElement('button');
+      viewButton.className = 'group-view';
+      viewButton.type = 'button';
+      viewButton.textContent = 'View all';
+      viewButton.onclick = function() {
+        selectCategory(group);
+      };
+      header.appendChild(viewButton);
+    }
+
+    section.appendChild(header);
+
+    var groupGrid = document.createElement('div');
+    groupGrid.className = 'group-grid';
+    groups[group].slice(0, 3).forEach(function(p) {
+      groupGrid.appendChild(createCard(p));
+    });
+    section.appendChild(groupGrid);
+    groupedEl.appendChild(section);
+  });
 }
 
 function renderCards(pages) {
   var grid = document.getElementById('grid');
+  var groupedEl = document.getElementById('grouped');
   var empty = document.getElementById('empty');
   var count = document.getElementById('page-count');
   grid.innerHTML = '';
+  groupedEl.innerHTML = '';
 
   if (!pages || pages.length === 0) {
     grid.style.display = 'none';
+    groupedEl.style.display = 'none';
     empty.style.display = '';
-    count.textContent = allPages.length ? '0 of ' + allPages.length + ' pages' : '';
+    count.textContent = allPages.length
+      ? (filters.category ? filters.category + ' · 0 pages' : '0 of ' + allPages.length + ' pages')
+      : '';
     empty.querySelector('p').innerHTML = allPages.length
       ? 'No pages match the current filters.'
       : 'No pages yet.<br>Use the factory to brainstorm your first page.';
     return;
   }
 
-  grid.style.display = 'grid';
   empty.style.display = 'none';
-  count.textContent = pages.length + ' of ' + allPages.length + (allPages.length === 1 ? ' page' : ' pages');
+  updateHeader(pages);
 
-  pages.forEach(function(p) {
-    var card = document.createElement('div');
-    card.className = 'card';
-    card.onclick = function() { window.location.href = buildFactoryHref(p.page); };
+  if (isGroupedDefaultView()) {
+    grid.style.display = 'none';
+    groupedEl.style.display = 'grid';
+    renderGroupedCards(groupedEl, pages);
+  } else {
+    groupedEl.style.display = 'none';
+    grid.style.display = 'grid';
+    renderFlatCards(grid, pages);
+  }
 
-    // Thumbnail
-    var thumb = document.createElement('div');
-    thumb.className = 'card-thumb';
-    if (p.latestFile) {
-      var iframe = document.createElement('iframe');
-      iframe.src = '/prototype?file=' + encodeURIComponent(p.latestFile);
-      iframe.setAttribute('loading', 'lazy');
-      iframe.setAttribute('tabindex', '-1');
-      thumb.appendChild(iframe);
-    }
-    card.appendChild(thumb);
-
-    // Body
-    var body = document.createElement('div');
-    body.className = 'card-body';
-
-    var name = document.createElement('div');
-    name.className = 'card-name';
-    name.textContent = p.name || p.page;
-    body.appendChild(name);
-
-    var meta = document.createElement('div');
-    meta.className = 'card-meta';
-
-    var vBadge = document.createElement('span');
-    vBadge.className = 'badge badge-versions';
-    vBadge.textContent = p.versions + (p.versions === 1 ? ' version' : ' versions');
-    meta.appendChild(vBadge);
-
-    if (p.group && p.group !== 'Ungrouped') {
-      var gBadge = document.createElement('span');
-      gBadge.className = 'badge badge-group';
-      gBadge.textContent = p.group;
-      meta.appendChild(gBadge);
-    }
-
-    if (p.selectedOption) {
-      var sBadge = document.createElement('span');
-      sBadge.className = 'badge badge-selected';
-      sBadge.textContent = p.selectedOption;
-      meta.appendChild(sBadge);
-    }
-
-    if (p.lastModified) {
-      var time = document.createElement('span');
-      time.className = 'badge-time';
-      time.textContent = relativeTime(p.lastModified);
-      meta.appendChild(time);
-    }
-
-    body.appendChild(meta);
-    card.appendChild(body);
-    grid.appendChild(card);
-  });
+  scheduleThumbScale();
 }
 
 fetch('/api/page-status')
@@ -365,12 +608,19 @@ fetch('/api/page-status')
   .then(function(pages) {
     allPages = pages || [];
     updateCategoryOptions(allPages);
+    applyUrlFilters();
+    syncCategoryUrl('replace');
     renderCards(getFilteredPages());
   })
   .catch(function(err) {
     document.getElementById('empty').style.display = '';
     document.getElementById('empty').querySelector('p').textContent = 'Failed to load: ' + err.message;
   });
+
+window.addEventListener('popstate', function() {
+  applyUrlFilters();
+  renderCards(getFilteredPages());
+});
 </script>
 </body>
 </html>

--- a/plugins/ctx/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/server.js
@@ -470,13 +470,8 @@ function servePage(res, filePath) {
 function serveBrainstorm(res) {
   const file = newestHtml();
   if (!file) {
-    res.writeHead(200, { "Content-Type": "text/html" });
-    res.end(
-      frameTemplate.replace(
-        "{{CONTENT}}",
-        '<div class="waiting">Waiting for content...</div>'
-      )
-    );
+    res.writeHead(302, { Location: "/factory" });
+    res.end();
     return;
   }
   const content = fs.readFileSync(path.join(screenDir, file), "utf8");
@@ -790,7 +785,7 @@ const server = http.createServer((req, res) => {
     handleStatus(req, res);
   } else if (parsed.pathname === "/playground") {
     servePlayground(res);
-  } else if (parsed.pathname === "/page" && parsed.searchParams.get("file")) {
+  } else if ((parsed.pathname === "/page" || parsed.pathname === "/prototype") && parsed.searchParams.get("file")) {
     servePage(res, parsed.searchParams.get("file"));
   } else if (parsed.pathname === "/api/slots") {
     jsonResponse(res, 200, scanSlots());


### PR DESCRIPTION
## Summary
- group the Factory portfolio by category by default, with category-scoped URLs and an explicit All pages escape path
- improve portfolio card readability with responsive iframe thumbnail scaling and larger metadata/type
- update the Factory editor chrome with a stable Factory back link, fixed right-side page/version controls, and remove the obsolete bottom prompt bar
- refine the editor sidebar: segmented Compact/Expand category mode control, active-category-only compact default, promoted Versions block under page filters, and separate top-level Re-scan project row
- add Edit pages mode with soft archive actions that move whole page folders from factory/pages into factory/archive
- redirect bare / to /factory when no transient brainstorm preview exists; add a Claude-side /prototype compatibility alias for portfolio thumbnails
- bump both plugin manifests to 0.2.9.7 and document the release note

## Validation
- node --check plugins/ctx/skills/ctx-brainstorm/factory/server.js
- node --check plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
- node -e portfolio checks passed
- node -e factory editor checks passed
- node -e server checks passed
- node -e editor sidebar checks passed
- node -e segmented toggle checks passed
- node -e archive UI checks passed
- node -e archive server checks passed
- git diff --check
- in-app browser smoke: /factory grouped portfolio, /factory?category=my-lab category state, editor sidebar compact/expand/version/rescan controls, Edit pages archive affordances

## Notes
- Full script harnesses were attempted for both runtimes. They fail on existing harness/setup issues unrelated to this change: Claude harness reports .env symlink expectations in worktree-post-setup; Codex harness writes .codex/skill-invocations.log without creating .codex first.
- I did not archive a real page during validation; archive remains behind an explicit browser confirmation.