### PR TITLE
Add reversible CTX Factory archiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.9.7 (2026-05-15)
 
-- **Factory portfolio chrome** — portfolio cards now use responsive preview scaling, larger readable metadata, grouped default sections, category-scoped URLs (`/factory?category=...`), and an explicit `All pages` escape path. The editor top bar now includes a stable `Factory` back link, keeps page/version controls fixed on the right, and removes the obsolete bottom prompt bar. Bare `/` redirects to `/factory` when no transient brainstorm preview exists.
+- **Factory portfolio chrome** — portfolio cards now use responsive preview scaling, larger readable metadata, grouped default sections, category-scoped URLs (`/factory?category=...`), and an explicit `All pages` escape path. The editor top bar now includes a stable `Factory` back link, keeps page/version controls fixed on the right, promotes versions and rescan actions into the Pages area, adds compact/expanded page group modes, supports soft-archiving whole pages into `factory/archive/`, and removes the obsolete bottom prompt bar. Bare `/` redirects to `/factory` when no transient brainstorm preview exists.
 
 ## 0.2.9.6 (2026-04-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.9.7 (2026-05-15)
 
-- **Factory portfolio chrome** — portfolio cards now use responsive preview scaling, larger readable metadata, grouped default sections, category-scoped URLs (`/factory?category=...`), and an explicit `All pages` escape path. The editor top bar now includes a stable `Factory` back link, keeps page/version controls fixed on the right, promotes versions and the only rescan action into the Pages area, adds compact/expanded page group modes, clarifies style controls as preview overrides, supports soft-archiving whole pages into `factory/archive/`, and removes the obsolete bottom prompt bar. Bare `/` redirects to `/factory` when no transient brainstorm preview exists.
+- **Factory portfolio chrome** — portfolio cards now use responsive preview scaling, larger readable metadata, grouped default sections, category-scoped URLs (`/factory?category=...`), and an explicit `All pages` escape path. The editor top bar now includes a stable `Factory` back link, keeps page/version controls fixed on the right, promotes versions and the only rescan action into the Pages area, adds compact/expanded page group modes, clarifies style controls as preview overrides, supports icon-led edit mode with modal-confirmed soft archiving plus archive restore from `factory/archive/`, and removes the obsolete bottom prompt bar. Bare `/` redirects to `/factory` when no transient brainstorm preview exists.
 
 ## 0.2.9.6 (2026-04-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.9.7 (2026-05-15)
 
-- **Factory portfolio chrome** — portfolio cards now use responsive preview scaling, larger readable metadata, grouped default sections, category-scoped URLs (`/factory?category=...`), and an explicit `All pages` escape path. The editor top bar now includes a stable `Factory` back link, keeps page/version controls fixed on the right, promotes versions and rescan actions into the Pages area, adds compact/expanded page group modes, supports soft-archiving whole pages into `factory/archive/`, and removes the obsolete bottom prompt bar. Bare `/` redirects to `/factory` when no transient brainstorm preview exists.
+- **Factory portfolio chrome** — portfolio cards now use responsive preview scaling, larger readable metadata, grouped default sections, category-scoped URLs (`/factory?category=...`), and an explicit `All pages` escape path. The editor top bar now includes a stable `Factory` back link, keeps page/version controls fixed on the right, promotes versions and the only rescan action into the Pages area, adds compact/expanded page group modes, clarifies style controls as preview overrides, supports soft-archiving whole pages into `factory/archive/`, and removes the obsolete bottom prompt bar. Bare `/` redirects to `/factory` when no transient brainstorm preview exists.
 
 ## 0.2.9.6 (2026-04-22)
 

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
@@ -337,6 +337,45 @@
     width: 100%;
     border-color: #334155;
   }
+  .page-edit-row {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+  .page-row.editing {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .page-row-main {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+  .page-row-actions {
+    display: none;
+    justify-content: flex-end;
+  }
+  .page-row.editing .page-row-actions {
+    display: flex;
+  }
+  .page-archive-btn {
+    background: rgba(248, 113, 113, 0.08);
+    color: #fca5a5;
+    border: 1px solid rgba(248, 113, 113, 0.28);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.64rem;
+    font-weight: 650;
+    padding: 0.22rem 0.45rem;
+  }
+  .page-archive-btn:hover,
+  .page-archive-btn:focus {
+    border-color: #f87171;
+    outline: none;
+  }
   .page-results {
     font-size: 0.65rem;
     color: #64748b;
@@ -712,6 +751,9 @@
           </div>
           <button class="page-tool-btn btn-rescan" id="page-rescan" type="button" onclick="triggerRescan()">Re-scan project</button>
         </div>
+        <div class="page-edit-row">
+          <button class="page-tool-btn" id="page-edit-toggle" type="button" onclick="togglePageEditMode()" aria-pressed="false">Edit pages</button>
+        </div>
         <div class="page-versions" id="versions-section">
           <span class="page-versions-label">Versions</span>
           <div class="version-pills" id="version-pills">
@@ -756,6 +798,7 @@ var compareItems = [];
 var currentViewport = 'desktop';
 var expandedGroups = {};
 var pageGroupMode = 'compact';
+var pageEditMode = false;
 var previewFileBase = '/prototype?file=';
 var pageFilters = { query: '', category: '', sort: 'updated-desc' };
 
@@ -921,6 +964,20 @@ function setPageGroupMode(mode) {
     expandedGroups[groupName] = pageGroupMode === 'expanded' || groupName === activeGroup;
   });
   updatePageGroupModeButtons();
+  renderPagesList();
+}
+
+function updatePageEditButton() {
+  var btn = document.getElementById('page-edit-toggle');
+  if (!btn) return;
+  btn.classList.toggle('active', pageEditMode);
+  btn.setAttribute('aria-pressed', pageEditMode ? 'true' : 'false');
+  btn.textContent = pageEditMode ? 'Done editing' : 'Edit pages';
+}
+
+function togglePageEditMode() {
+  pageEditMode = !pageEditMode;
+  updatePageEditButton();
   renderPagesList();
 }
 
@@ -1129,12 +1186,28 @@ function renderPagesList() {
 
     grouped[groupName].forEach(function(slotData) {
       var row = document.createElement('div');
-      row.className = 'page-row' + (slotData.slot === activePage ? ' active' : '');
+      row.className = 'page-row' + (slotData.slot === activePage ? ' active' : '') + (pageEditMode ? ' editing' : '');
       row.dataset.slot = slotData.slot;
 
-      row.appendChild(makeText('span', 'page-row-name', getPageLabel(slotData)));
-      row.appendChild(makeText('span', 'page-row-count', slotData.iterations.length + ''));
-      row.onclick = function() { activatePage(slotData.slot, true); };
+      var rowMain = document.createElement('div');
+      rowMain.className = 'page-row-main';
+      rowMain.appendChild(makeText('span', 'page-row-name', getPageLabel(slotData)));
+      rowMain.appendChild(makeText('span', 'page-row-count', slotData.iterations.length + ''));
+      rowMain.onclick = function() { activatePage(slotData.slot, true); };
+      row.appendChild(rowMain);
+
+      var actions = document.createElement('div');
+      actions.className = 'page-row-actions';
+      var archiveBtn = document.createElement('button');
+      archiveBtn.className = 'page-archive-btn';
+      archiveBtn.type = 'button';
+      archiveBtn.textContent = 'Archive page';
+      archiveBtn.onclick = function(event) {
+        event.stopPropagation();
+        archivePage(slotData);
+      };
+      actions.appendChild(archiveBtn);
+      row.appendChild(actions);
 
       rows.appendChild(row);
     });
@@ -1221,6 +1294,53 @@ function updateVersionPills() {
   }
 }
 
+function loadSlots() {
+  return fetch('/api/slots')
+    .then(function(r) { return r.json(); })
+    .then(function(slots) {
+      renderSlots(slots);
+      return slots;
+    })
+    .catch(function(err) {
+      var ph = document.getElementById('preview-placeholder');
+      if (ph) {
+        ph.style.display = '';
+        document.getElementById('preview-placeholder-msg').textContent = 'Failed to load slots: ' + err.message;
+      }
+      var errOpt = document.createElement('option');
+      errOpt.value = '';
+      errOpt.textContent = 'Error loading';
+      document.getElementById('proto-select').appendChild(errOpt);
+      updatePageNavButtons();
+      return [];
+    });
+}
+
+function archivePage(slotData) {
+  if (!slotData) return;
+  var label = getPageContextLabel(slotData);
+  var confirmed = window.confirm('Archive page: ' + label + '?\\n\\nThis moves it to factory/archive so it can be restored manually.');
+  if (!confirmed) return;
+
+  fetch('/api/archive-page', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ page: slotData.slot })
+  })
+    .then(function(r) { return r.json().then(function(data) { return { ok: r.ok, data: data }; }); })
+    .then(function(result) {
+      if (!result.ok) throw new Error(result.data && result.data.error ? result.data.error : 'Archive failed');
+      if (slotData.slot === activePage) {
+        window.location.href = '/factory';
+        return;
+      }
+      loadSlots();
+    })
+    .catch(function(err) {
+      window.alert('Could not archive page: ' + err.message);
+    });
+}
+
 // --- Slot rendering ---
 function renderSlots(slots) {
   allSlots = slots || [];
@@ -1258,23 +1378,7 @@ function renderSlots(slots) {
 }
 
 // --- Load slots ---
-fetch('/api/slots')
-  .then(function(r) { return r.json(); })
-  .then(function(slots) {
-    renderSlots(slots);
-  })
-  .catch(function(err) {
-    var ph = document.getElementById('preview-placeholder');
-    if (ph) {
-      ph.style.display = '';
-      document.getElementById('preview-placeholder-msg').textContent = 'Failed to load slots: ' + err.message;
-    }
-    var errOpt = document.createElement('option');
-    errOpt.value = '';
-    errOpt.textContent = 'Error loading';
-    document.getElementById('proto-select').appendChild(errOpt);
-    updatePageNavButtons();
-  });
+loadSlots();
 
 // --- Style Controls ---
 var styleProfile = null;

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
@@ -571,6 +571,12 @@
     color: #475569;
     font-style: italic;
   }
+  .style-controls-note {
+    font-size: 0.66rem;
+    color: #64748b;
+    line-height: 1.4;
+    margin: 0 0 0.5rem;
+  }
   .empty-hint {
     font-size: 0.72rem;
     color: #475569;
@@ -1608,12 +1614,7 @@ function buildStyleControls(profile) {
   clearChildren(container);
 
   if (!profile) {
-    container.appendChild(makeText('span', 'style-no-profile', 'No profile found. Run Re-scan.'));
-    var rescanBtn = document.createElement('button');
-    rescanBtn.className = 'btn-rescan';
-    rescanBtn.textContent = 'Re-scan';
-    rescanBtn.onclick = triggerRescan;
-    container.appendChild(rescanBtn);
+    container.appendChild(makeText('span', 'style-no-profile', 'No profile found. Use Re-scan project above to refresh styles.'));
     return;
   }
 
@@ -1622,6 +1623,11 @@ function buildStyleControls(profile) {
   var t = profile.typography || {};
   var sp = profile.spacing || {};
   var r = sp.radius || {};
+
+  var note = document.createElement('p');
+  note.className = 'style-controls-note';
+  note.textContent = 'Preview overrides apply to prototypes that use Factory CSS variables.';
+  container.appendChild(note);
 
   // Colors
   var colorKeys = ['primary', 'accent', 'background', 'foreground', 'muted', 'secondary', 'destructive'];
@@ -1663,7 +1669,7 @@ function buildStyleControls(profile) {
 
   var resetBtn = document.createElement('button');
   resetBtn.className = 'btn-reset';
-  resetBtn.textContent = 'Reset to profile';
+  resetBtn.textContent = 'Reset preview overrides';
   resetBtn.onclick = function() {
     styleOverrides = {};
     buildStyleControls(styleProfile);
@@ -1672,17 +1678,6 @@ function buildStyleControls(profile) {
     if (iframe) iframe.src = iframe.src;
   };
   container.appendChild(resetBtn);
-
-  var rescanDesc = document.createElement('p');
-  rescanDesc.style.cssText = 'font-size:0.62rem;color:#475569;line-height:1.4;margin-bottom:0.35rem;';
-  rescanDesc.textContent = 'Re-reads your project\u2019s tailwind config, CSS vars, and package.json to update the controls above.';
-  container.appendChild(rescanDesc);
-
-  var rescanBtn = document.createElement('button');
-  rescanBtn.className = 'btn-rescan';
-  rescanBtn.textContent = 'Re-scan project';
-  rescanBtn.onclick = triggerRescan;
-  container.appendChild(rescanBtn);
 }
 
 function loadStyleProfile() {

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/factory.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Tinker Factory</title>
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   body {
@@ -341,6 +342,24 @@
     display: grid;
     grid-template-columns: 1fr;
   }
+  .page-tool-btn.with-icon,
+  .page-archive-btn,
+  .page-restore-btn,
+  .modal-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.32rem;
+  }
+  .page-tool-btn [data-lucide],
+  .page-archive-btn [data-lucide],
+  .page-restore-btn [data-lucide],
+  .modal-btn [data-lucide] {
+    width: 0.78rem;
+    height: 0.78rem;
+    stroke-width: 2.2;
+    flex-shrink: 0;
+  }
   .page-row.editing {
     align-items: stretch;
     flex-direction: column;
@@ -374,6 +393,80 @@
   .page-archive-btn:hover,
   .page-archive-btn:focus {
     border-color: #f87171;
+    outline: none;
+  }
+  .archive-manager {
+    display: none;
+    border: 1px solid #1e293b;
+    border-radius: 6px;
+    padding: 0.5rem;
+    background: rgba(15, 23, 42, 0.56);
+    gap: 0.35rem;
+  }
+  .archive-manager.visible {
+    display: grid;
+  }
+  .archive-manager-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    color: #cbd5e1;
+    font-size: 0.66rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .archive-manager-list {
+    display: grid;
+    gap: 0.3rem;
+  }
+  .archive-empty {
+    color: #64748b;
+    font-size: 0.66rem;
+    line-height: 1.35;
+  }
+  .archive-row {
+    display: grid;
+    gap: 0.35rem;
+    padding: 0.42rem;
+    border: 1px solid #1e293b;
+    border-radius: 5px;
+    background: #0a0e17;
+  }
+  .archive-row-main {
+    min-width: 0;
+  }
+  .archive-row-name {
+    display: block;
+    color: #cbd5e1;
+    font-size: 0.69rem;
+    font-weight: 650;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .archive-row-meta {
+    display: block;
+    color: #64748b;
+    font-size: 0.61rem;
+    margin-top: 0.12rem;
+  }
+  .page-restore-btn {
+    justify-self: start;
+    background: rgba(45, 212, 191, 0.08);
+    color: #5eead4;
+    border: 1px solid rgba(45, 212, 191, 0.28);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.64rem;
+    font-weight: 650;
+    padding: 0.22rem 0.45rem;
+  }
+  .page-restore-btn:hover,
+  .page-restore-btn:focus {
+    border-color: #2dd4bf;
     outline: none;
   }
   .page-results {
@@ -582,6 +675,66 @@
     color: #475569;
     font-style: italic;
   }
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 30;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    background: rgba(2, 6, 23, 0.72);
+  }
+  .modal-backdrop.visible {
+    display: flex;
+  }
+  .modal-dialog {
+    width: min(420px, 100%);
+    border: 1px solid #334155;
+    border-radius: 8px;
+    background: #0f172a;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+    padding: 1rem;
+  }
+  .modal-title {
+    color: #f8fafc;
+    font-size: 0.95rem;
+    font-weight: 750;
+    margin-bottom: 0.35rem;
+  }
+  .modal-body {
+    color: #94a3b8;
+    font-size: 0.76rem;
+    line-height: 1.45;
+  }
+  .modal-page-name {
+    color: #e2e8f0;
+    font-weight: 700;
+  }
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+  .modal-btn {
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 0.42rem 0.65rem;
+  }
+  .modal-btn-secondary {
+    background: transparent;
+    color: #cbd5e1;
+    border: 1px solid #334155;
+  }
+  .modal-btn-danger {
+    background: rgba(248, 113, 113, 0.12);
+    color: #fecaca;
+    border: 1px solid rgba(248, 113, 113, 0.42);
+  }
 
   /* Preview area */
   .preview-area {
@@ -758,7 +911,15 @@
           <button class="page-tool-btn btn-rescan" id="page-rescan" type="button" onclick="triggerRescan()">Re-scan project</button>
         </div>
         <div class="page-edit-row">
-          <button class="page-tool-btn" id="page-edit-toggle" type="button" onclick="togglePageEditMode()" aria-pressed="false">Edit pages</button>
+          <button class="page-tool-btn with-icon" id="page-edit-toggle" type="button" onclick="togglePageEditMode()" aria-pressed="false" title="Edit pages"></button>
+        </div>
+        <div class="archive-manager" id="archive-manager">
+          <div class="archive-manager-title">
+            <span>Archived pages</span>
+          </div>
+          <div class="archive-manager-list" id="archive-list">
+            <span class="archive-empty">Loading archived pages...</span>
+          </div>
         </div>
         <div class="page-versions" id="versions-section">
           <span class="page-versions-label">Versions</span>
@@ -793,18 +954,36 @@
   </div>
 </div>
 
+<div class="modal-backdrop" id="archive-modal" role="dialog" aria-modal="true" aria-labelledby="archive-modal-title">
+  <div class="modal-dialog">
+    <div class="modal-title" id="archive-modal-title">Archive page?</div>
+    <div class="modal-body">
+      This moves <span class="modal-page-name" id="archive-modal-page"></span> out of active Factory pages and into <span class="modal-page-name">factory/archive</span>. You can restore it later from Edit pages.
+    </div>
+    <div class="modal-actions">
+      <button class="modal-btn modal-btn-secondary" type="button" onclick="closeArchiveModal()">Cancel</button>
+      <button class="modal-btn modal-btn-danger" id="archive-confirm-btn" type="button" onclick="confirmArchivePage()">
+        <i data-lucide="archive"></i>
+        <span>Archive page</span>
+      </button>
+    </div>
+  </div>
+</div>
+
 <script>
 // --- State ---
 var activeFile = null;
 var activePage = null;
 var activeVersion = null;
 var allSlots = [];
+var archivedSlots = [];
 var compareMode = false;
 var compareItems = [];
 var currentViewport = 'desktop';
 var expandedGroups = {};
 var pageGroupMode = 'compact';
 var pageEditMode = false;
+var pendingArchiveSlot = null;
 var previewFileBase = '/prototype?file=';
 var pageFilters = { query: '', category: '', sort: 'updated-desc' };
 
@@ -839,6 +1018,26 @@ function makeText(tag, className, text) {
   if (className) el.className = className;
   el.textContent = text;
   return el;
+}
+
+function iconEl(name) {
+  var el = document.createElement('i');
+  el.setAttribute('data-lucide', name);
+  el.setAttribute('aria-hidden', 'true');
+  return el;
+}
+
+function setIconButtonContent(button, iconName, label) {
+  clearChildren(button);
+  button.appendChild(iconEl(iconName));
+  button.appendChild(makeText('span', '', label));
+  refreshIcons();
+}
+
+function refreshIcons() {
+  if (window.lucide && typeof window.lucide.createIcons === 'function') {
+    window.lucide.createIcons();
+  }
 }
 
 function buildPreviewUrl(filePath) {
@@ -978,12 +1177,15 @@ function updatePageEditButton() {
   if (!btn) return;
   btn.classList.toggle('active', pageEditMode);
   btn.setAttribute('aria-pressed', pageEditMode ? 'true' : 'false');
-  btn.textContent = pageEditMode ? 'Done editing' : 'Edit pages';
+  btn.title = pageEditMode ? 'Done editing' : 'Edit pages';
+  setIconButtonContent(btn, pageEditMode ? 'check' : 'square-pen', pageEditMode ? 'Done editing' : 'Edit pages');
 }
 
 function togglePageEditMode() {
   pageEditMode = !pageEditMode;
   updatePageEditButton();
+  renderArchiveManager();
+  if (pageEditMode) loadArchivedSlots();
   renderPagesList();
 }
 
@@ -1207,10 +1409,12 @@ function renderPagesList() {
       var archiveBtn = document.createElement('button');
       archiveBtn.className = 'page-archive-btn';
       archiveBtn.type = 'button';
-      archiveBtn.textContent = 'Archive page';
+      archiveBtn.title = 'Archive page';
+      archiveBtn.appendChild(iconEl('archive'));
+      archiveBtn.appendChild(makeText('span', '', 'Archive page'));
       archiveBtn.onclick = function(event) {
         event.stopPropagation();
-        archivePage(slotData);
+        openArchiveModal(slotData);
       };
       actions.appendChild(archiveBtn);
       row.appendChild(actions);
@@ -1221,6 +1425,7 @@ function renderPagesList() {
     group.appendChild(rows);
     pagesList.appendChild(group);
   });
+  refreshIcons();
 }
 
 function selectInitialPage() {
@@ -1322,11 +1527,86 @@ function loadSlots() {
     });
 }
 
+function loadArchivedSlots() {
+  return fetch('/api/archived-pages')
+    .then(function(r) { return r.json(); })
+    .then(function(slots) {
+      archivedSlots = slots || [];
+      renderArchiveManager();
+      return archivedSlots;
+    })
+    .catch(function() {
+      archivedSlots = [];
+      renderArchiveManager('Could not load archived pages');
+      return [];
+    });
+}
+
+function renderArchiveManager(errorText) {
+  var panel = document.getElementById('archive-manager');
+  var list = document.getElementById('archive-list');
+  if (!panel || !list) return;
+  panel.classList.toggle('visible', pageEditMode);
+  clearChildren(list);
+  if (!pageEditMode) return;
+  if (errorText) {
+    list.appendChild(makeText('span', 'archive-empty', errorText));
+    return;
+  }
+  if (!archivedSlots || archivedSlots.length === 0) {
+    list.appendChild(makeText('span', 'archive-empty', 'No archived pages yet.'));
+    return;
+  }
+  archivedSlots.forEach(function(slotData) {
+    var row = document.createElement('div');
+    row.className = 'archive-row';
+
+    var main = document.createElement('div');
+    main.className = 'archive-row-main';
+    main.appendChild(makeText('span', 'archive-row-name', getPageContextLabel(slotData)));
+    main.appendChild(makeText('span', 'archive-row-meta', slotData.iterations.length + ' version' + (slotData.iterations.length === 1 ? '' : 's')));
+    row.appendChild(main);
+
+    var restoreBtn = document.createElement('button');
+    restoreBtn.className = 'page-restore-btn';
+    restoreBtn.type = 'button';
+    restoreBtn.title = 'Restore page';
+    restoreBtn.appendChild(iconEl('rotate-ccw'));
+    restoreBtn.appendChild(makeText('span', '', 'Restore'));
+    restoreBtn.onclick = function() { restoreArchivedPage(slotData); };
+    row.appendChild(restoreBtn);
+
+    list.appendChild(row);
+  });
+  refreshIcons();
+}
+
+function openArchiveModal(slotData) {
+  if (!slotData) return;
+  pendingArchiveSlot = slotData;
+  var pageName = document.getElementById('archive-modal-page');
+  if (pageName) pageName.textContent = getPageContextLabel(slotData);
+  var modal = document.getElementById('archive-modal');
+  if (modal) modal.classList.add('visible');
+  refreshIcons();
+}
+
+function closeArchiveModal() {
+  pendingArchiveSlot = null;
+  var modal = document.getElementById('archive-modal');
+  if (modal) modal.classList.remove('visible');
+}
+
+function confirmArchivePage() {
+  var slotData = pendingArchiveSlot;
+  if (!slotData) return;
+  archivePage(slotData);
+}
+
 function archivePage(slotData) {
   if (!slotData) return;
-  var label = getPageContextLabel(slotData);
-  var confirmed = window.confirm('Archive page: ' + label + '?\\n\\nThis moves it to factory/archive so it can be restored manually.');
-  if (!confirmed) return;
+  var btn = document.getElementById('archive-confirm-btn');
+  if (btn) btn.disabled = true;
 
   fetch('/api/archive-page', {
     method: 'POST',
@@ -1336,14 +1616,39 @@ function archivePage(slotData) {
     .then(function(r) { return r.json().then(function(data) { return { ok: r.ok, data: data }; }); })
     .then(function(result) {
       if (!result.ok) throw new Error(result.data && result.data.error ? result.data.error : 'Archive failed');
+      closeArchiveModal();
       if (slotData.slot === activePage) {
         window.location.href = '/factory';
         return;
       }
       loadSlots();
+      loadArchivedSlots();
     })
     .catch(function(err) {
       window.alert('Could not archive page: ' + err.message);
+    })
+    .then(function() {
+      if (btn) btn.disabled = false;
+    });
+}
+
+function restoreArchivedPage(slotData) {
+  if (!slotData) return;
+  fetch('/api/restore-page', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ page: slotData.slot })
+  })
+    .then(function(r) { return r.json().then(function(data) { return { ok: r.ok, data: data }; }); })
+    .then(function(result) {
+      if (!result.ok) throw new Error(result.data && result.data.error ? result.data.error : 'Restore failed');
+      return loadSlots();
+    })
+    .then(function() {
+      loadArchivedSlots();
+    })
+    .catch(function(err) {
+      window.alert('Could not restore page: ' + err.message);
     });
 }
 
@@ -1384,6 +1689,8 @@ function renderSlots(slots) {
 }
 
 // --- Load slots ---
+updatePageEditButton();
+renderArchiveManager();
 loadSlots();
 
 // --- Style Controls ---
@@ -1841,7 +2148,9 @@ function exitCompareMode() {
 }
 
 document.addEventListener('keydown', function(e) {
-  if (e.key === 'Escape' && compareMode) {
+  if (e.key === 'Escape' && document.getElementById('archive-modal').classList.contains('visible')) {
+    closeArchiveModal();
+  } else if (e.key === 'Escape' && compareMode) {
     exitCompareMode();
   }
 });

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
@@ -507,10 +507,8 @@ function sanitizePathPart(value) {
   return String(value || "").trim().replace(/[^a-zA-Z0-9_-]/g, "");
 }
 
-function scanSlots() {
-  if (!pagesRoot) return [];
-  const factoryPagesDir = path.join(pagesRoot, "factory/pages");
-  if (!fs.existsSync(factoryPagesDir)) return [];
+function scanSlotDirectory(rootDir) {
+  if (!fs.existsSync(rootDir)) return [];
 
   const slots = new Map();
 
@@ -558,7 +556,7 @@ function scanSlots() {
     }
   }
 
-  scan(factoryPagesDir, "");
+  scan(rootDir, "");
 
   // Sort iterations within each slot by version number
   const result = [];
@@ -580,6 +578,16 @@ function scanSlots() {
     return a.page.localeCompare(b.page);
   });
   return result;
+}
+
+function scanSlots() {
+  if (!pagesRoot) return [];
+  return scanSlotDirectory(path.join(pagesRoot, "factory/pages"));
+}
+
+function scanArchivedSlots() {
+  if (!pagesRoot) return [];
+  return scanSlotDirectory(path.join(pagesRoot, "factory/archive"));
 }
 
 // ========== Auto-Versioning ==========
@@ -803,6 +811,52 @@ async function handleArchivePage(req, res) {
   });
 }
 
+async function handleRestorePage(req, res) {
+  if (!pagesRoot) {
+    jsonResponse(res, 400, { error: "No --project-dir configured" });
+    return;
+  }
+
+  const body = await readBody(req);
+  if (!body || !body.page) {
+    jsonResponse(res, 400, { error: "Missing page" });
+    return;
+  }
+
+  const slot = String(body.page).trim();
+  const slotData = scanArchivedSlots().find(s => s.slot === slot);
+  if (!slotData) {
+    jsonResponse(res, 404, { error: "Archived page not found" });
+    return;
+  }
+
+  const pagesDir = path.resolve(pagesRoot, "factory/pages");
+  const archiveDir = path.resolve(pagesRoot, "factory/archive");
+  const source = path.resolve(archiveDir, slotData.slot);
+  const target = path.resolve(pagesDir, slotData.slot);
+  if (!source.startsWith(archiveDir + path.sep) || !fs.existsSync(source)) {
+    jsonResponse(res, 404, { error: "Archived page directory not found" });
+    return;
+  }
+  if (!target.startsWith(pagesDir + path.sep)) {
+    jsonResponse(res, 403, { error: "Forbidden restore path" });
+    return;
+  }
+  if (fs.existsSync(target)) {
+    jsonResponse(res, 409, { error: "An active page already exists at this path" });
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.renameSync(source, target);
+  broadcast({ type: "reload" });
+  jsonResponse(res, 200, {
+    ok: true,
+    page: slotData.slot,
+    restoredTo: path.relative(pagesRoot, target),
+  });
+}
+
 function servePortfolio(res) {
   const portfolioPath = path.join(__dirname, "portfolio.html");
   if (!fs.existsSync(portfolioPath)) {
@@ -852,8 +906,12 @@ const server = http.createServer((req, res) => {
     handleWrite(req, res);
   } else if (parsed.pathname === "/api/page-status") {
     handlePageStatus(req, res);
+  } else if (parsed.pathname === "/api/archived-pages") {
+    jsonResponse(res, 200, scanArchivedSlots());
   } else if (parsed.pathname === "/api/archive-page" && req.method === "POST") {
     handleArchivePage(req, res);
+  } else if (parsed.pathname === "/api/restore-page" && req.method === "POST") {
+    handleRestorePage(req, res);
   } else if (parsed.pathname === "/api/compare" && req.method === "POST") {
     handleCompare(req, res);
   } else if (parsed.pathname === "/api/style-profile") {

--- a/plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
@@ -756,6 +756,53 @@ function handlePageStatus(req, res) {
   jsonResponse(res, 200, result);
 }
 
+async function handleArchivePage(req, res) {
+  if (!pagesRoot) {
+    jsonResponse(res, 400, { error: "No --project-dir configured" });
+    return;
+  }
+
+  const body = await readBody(req);
+  if (!body || !body.page) {
+    jsonResponse(res, 400, { error: "Missing page" });
+    return;
+  }
+
+  const slot = String(body.page).trim();
+  const slotData = scanSlots().find(s => s.slot === slot);
+  if (!slotData) {
+    jsonResponse(res, 404, { error: "Page not found" });
+    return;
+  }
+
+  const pagesDir = path.resolve(pagesRoot, "factory/pages");
+  const archiveDir = path.resolve(pagesRoot, "factory/archive");
+  const source = path.resolve(pagesDir, slotData.slot);
+  if (!source.startsWith(pagesDir + path.sep) || !fs.existsSync(source)) {
+    jsonResponse(res, 404, { error: "Page directory not found" });
+    return;
+  }
+
+  let target = path.resolve(archiveDir, slotData.slot);
+  if (!target.startsWith(archiveDir + path.sep)) {
+    jsonResponse(res, 403, { error: "Forbidden archive path" });
+    return;
+  }
+
+  if (fs.existsSync(target)) {
+    target = target + "-" + new Date().toISOString().replace(/[:.]/g, "-");
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.renameSync(source, target);
+  broadcast({ type: "reload" });
+  jsonResponse(res, 200, {
+    ok: true,
+    page: slotData.slot,
+    archivedTo: path.relative(pagesRoot, target),
+  });
+}
+
 function servePortfolio(res) {
   const portfolioPath = path.join(__dirname, "portfolio.html");
   if (!fs.existsSync(portfolioPath)) {
@@ -805,6 +852,8 @@ const server = http.createServer((req, res) => {
     handleWrite(req, res);
   } else if (parsed.pathname === "/api/page-status") {
     handlePageStatus(req, res);
+  } else if (parsed.pathname === "/api/archive-page" && req.method === "POST") {
+    handleArchivePage(req, res);
   } else if (parsed.pathname === "/api/compare" && req.method === "POST") {
     handleCompare(req, res);
   } else if (parsed.pathname === "/api/style-profile") {

--- a/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
@@ -337,6 +337,45 @@
     width: 100%;
     border-color: #334155;
   }
+  .page-edit-row {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+  .page-row.editing {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .page-row-main {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+  .page-row-actions {
+    display: none;
+    justify-content: flex-end;
+  }
+  .page-row.editing .page-row-actions {
+    display: flex;
+  }
+  .page-archive-btn {
+    background: rgba(248, 113, 113, 0.08);
+    color: #fca5a5;
+    border: 1px solid rgba(248, 113, 113, 0.28);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.64rem;
+    font-weight: 650;
+    padding: 0.22rem 0.45rem;
+  }
+  .page-archive-btn:hover,
+  .page-archive-btn:focus {
+    border-color: #f87171;
+    outline: none;
+  }
   .page-results {
     font-size: 0.65rem;
     color: #64748b;
@@ -712,6 +751,9 @@
           </div>
           <button class="page-tool-btn btn-rescan" id="page-rescan" type="button" onclick="triggerRescan()">Re-scan project</button>
         </div>
+        <div class="page-edit-row">
+          <button class="page-tool-btn" id="page-edit-toggle" type="button" onclick="togglePageEditMode()" aria-pressed="false">Edit pages</button>
+        </div>
         <div class="page-versions" id="versions-section">
           <span class="page-versions-label">Versions</span>
           <div class="version-pills" id="version-pills">
@@ -756,6 +798,7 @@ var compareItems = [];
 var currentViewport = 'desktop';
 var expandedGroups = {};
 var pageGroupMode = 'compact';
+var pageEditMode = false;
 var previewFileBase = '/page?file=';
 var pageFilters = { query: '', category: '', sort: 'updated-desc' };
 
@@ -921,6 +964,20 @@ function setPageGroupMode(mode) {
     expandedGroups[groupName] = pageGroupMode === 'expanded' || groupName === activeGroup;
   });
   updatePageGroupModeButtons();
+  renderPagesList();
+}
+
+function updatePageEditButton() {
+  var btn = document.getElementById('page-edit-toggle');
+  if (!btn) return;
+  btn.classList.toggle('active', pageEditMode);
+  btn.setAttribute('aria-pressed', pageEditMode ? 'true' : 'false');
+  btn.textContent = pageEditMode ? 'Done editing' : 'Edit pages';
+}
+
+function togglePageEditMode() {
+  pageEditMode = !pageEditMode;
+  updatePageEditButton();
   renderPagesList();
 }
 
@@ -1129,12 +1186,28 @@ function renderPagesList() {
 
     grouped[groupName].forEach(function(slotData) {
       var row = document.createElement('div');
-      row.className = 'page-row' + (slotData.slot === activePage ? ' active' : '');
+      row.className = 'page-row' + (slotData.slot === activePage ? ' active' : '') + (pageEditMode ? ' editing' : '');
       row.dataset.slot = slotData.slot;
 
-      row.appendChild(makeText('span', 'page-row-name', getPageLabel(slotData)));
-      row.appendChild(makeText('span', 'page-row-count', slotData.iterations.length + ''));
-      row.onclick = function() { activatePage(slotData.slot, true); };
+      var rowMain = document.createElement('div');
+      rowMain.className = 'page-row-main';
+      rowMain.appendChild(makeText('span', 'page-row-name', getPageLabel(slotData)));
+      rowMain.appendChild(makeText('span', 'page-row-count', slotData.iterations.length + ''));
+      rowMain.onclick = function() { activatePage(slotData.slot, true); };
+      row.appendChild(rowMain);
+
+      var actions = document.createElement('div');
+      actions.className = 'page-row-actions';
+      var archiveBtn = document.createElement('button');
+      archiveBtn.className = 'page-archive-btn';
+      archiveBtn.type = 'button';
+      archiveBtn.textContent = 'Archive page';
+      archiveBtn.onclick = function(event) {
+        event.stopPropagation();
+        archivePage(slotData);
+      };
+      actions.appendChild(archiveBtn);
+      row.appendChild(actions);
 
       rows.appendChild(row);
     });
@@ -1221,6 +1294,53 @@ function updateVersionPills() {
   }
 }
 
+function loadSlots() {
+  return fetch('/api/slots')
+    .then(function(r) { return r.json(); })
+    .then(function(slots) {
+      renderSlots(slots);
+      return slots;
+    })
+    .catch(function(err) {
+      var ph = document.getElementById('preview-placeholder');
+      if (ph) {
+        ph.style.display = '';
+        document.getElementById('preview-placeholder-msg').textContent = 'Failed to load slots: ' + err.message;
+      }
+      var errOpt = document.createElement('option');
+      errOpt.value = '';
+      errOpt.textContent = 'Error loading';
+      document.getElementById('proto-select').appendChild(errOpt);
+      updatePageNavButtons();
+      return [];
+    });
+}
+
+function archivePage(slotData) {
+  if (!slotData) return;
+  var label = getPageContextLabel(slotData);
+  var confirmed = window.confirm('Archive page: ' + label + '?\\n\\nThis moves it to factory/archive so it can be restored manually.');
+  if (!confirmed) return;
+
+  fetch('/api/archive-page', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ page: slotData.slot })
+  })
+    .then(function(r) { return r.json().then(function(data) { return { ok: r.ok, data: data }; }); })
+    .then(function(result) {
+      if (!result.ok) throw new Error(result.data && result.data.error ? result.data.error : 'Archive failed');
+      if (slotData.slot === activePage) {
+        window.location.href = '/factory';
+        return;
+      }
+      loadSlots();
+    })
+    .catch(function(err) {
+      window.alert('Could not archive page: ' + err.message);
+    });
+}
+
 // --- Slot rendering ---
 function renderSlots(slots) {
   allSlots = slots || [];
@@ -1258,23 +1378,7 @@ function renderSlots(slots) {
 }
 
 // --- Load slots ---
-fetch('/api/slots')
-  .then(function(r) { return r.json(); })
-  .then(function(slots) {
-    renderSlots(slots);
-  })
-  .catch(function(err) {
-    var ph = document.getElementById('preview-placeholder');
-    if (ph) {
-      ph.style.display = '';
-      document.getElementById('preview-placeholder-msg').textContent = 'Failed to load slots: ' + err.message;
-    }
-    var errOpt = document.createElement('option');
-    errOpt.value = '';
-    errOpt.textContent = 'Error loading';
-    document.getElementById('proto-select').appendChild(errOpt);
-    updatePageNavButtons();
-  });
+loadSlots();
 
 // --- Style Controls ---
 var styleProfile = null;

--- a/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
@@ -571,6 +571,12 @@
     color: #475569;
     font-style: italic;
   }
+  .style-controls-note {
+    font-size: 0.66rem;
+    color: #64748b;
+    line-height: 1.4;
+    margin: 0 0 0.5rem;
+  }
   .empty-hint {
     font-size: 0.72rem;
     color: #475569;
@@ -1608,12 +1614,7 @@ function buildStyleControls(profile) {
   clearChildren(container);
 
   if (!profile) {
-    container.appendChild(makeText('span', 'style-no-profile', 'No profile found. Run Re-scan.'));
-    var rescanBtn = document.createElement('button');
-    rescanBtn.className = 'btn-rescan';
-    rescanBtn.textContent = 'Re-scan';
-    rescanBtn.onclick = triggerRescan;
-    container.appendChild(rescanBtn);
+    container.appendChild(makeText('span', 'style-no-profile', 'No profile found. Use Re-scan project above to refresh styles.'));
     return;
   }
 
@@ -1622,6 +1623,11 @@ function buildStyleControls(profile) {
   var t = profile.typography || {};
   var sp = profile.spacing || {};
   var r = sp.radius || {};
+
+  var note = document.createElement('p');
+  note.className = 'style-controls-note';
+  note.textContent = 'Preview overrides apply to prototypes that use Factory CSS variables.';
+  container.appendChild(note);
 
   // Colors
   var colorKeys = ['primary', 'accent', 'background', 'foreground', 'muted', 'secondary', 'destructive'];
@@ -1663,7 +1669,7 @@ function buildStyleControls(profile) {
 
   var resetBtn = document.createElement('button');
   resetBtn.className = 'btn-reset';
-  resetBtn.textContent = 'Reset to profile';
+  resetBtn.textContent = 'Reset preview overrides';
   resetBtn.onclick = function() {
     styleOverrides = {};
     buildStyleControls(styleProfile);
@@ -1672,17 +1678,6 @@ function buildStyleControls(profile) {
     if (iframe) iframe.src = iframe.src;
   };
   container.appendChild(resetBtn);
-
-  var rescanDesc = document.createElement('p');
-  rescanDesc.style.cssText = 'font-size:0.62rem;color:#475569;line-height:1.4;margin-bottom:0.35rem;';
-  rescanDesc.textContent = 'Re-reads your project\u2019s tailwind config, CSS vars, and package.json to update the controls above.';
-  container.appendChild(rescanDesc);
-
-  var rescanBtn = document.createElement('button');
-  rescanBtn.className = 'btn-rescan';
-  rescanBtn.textContent = 'Re-scan project';
-  rescanBtn.onclick = triggerRescan;
-  container.appendChild(rescanBtn);
 }
 
 function loadStyleProfile() {

--- a/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/factory.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Tinker Factory</title>
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   body {
@@ -341,6 +342,24 @@
     display: grid;
     grid-template-columns: 1fr;
   }
+  .page-tool-btn.with-icon,
+  .page-archive-btn,
+  .page-restore-btn,
+  .modal-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.32rem;
+  }
+  .page-tool-btn [data-lucide],
+  .page-archive-btn [data-lucide],
+  .page-restore-btn [data-lucide],
+  .modal-btn [data-lucide] {
+    width: 0.78rem;
+    height: 0.78rem;
+    stroke-width: 2.2;
+    flex-shrink: 0;
+  }
   .page-row.editing {
     align-items: stretch;
     flex-direction: column;
@@ -374,6 +393,80 @@
   .page-archive-btn:hover,
   .page-archive-btn:focus {
     border-color: #f87171;
+    outline: none;
+  }
+  .archive-manager {
+    display: none;
+    border: 1px solid #1e293b;
+    border-radius: 6px;
+    padding: 0.5rem;
+    background: rgba(15, 23, 42, 0.56);
+    gap: 0.35rem;
+  }
+  .archive-manager.visible {
+    display: grid;
+  }
+  .archive-manager-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    color: #cbd5e1;
+    font-size: 0.66rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .archive-manager-list {
+    display: grid;
+    gap: 0.3rem;
+  }
+  .archive-empty {
+    color: #64748b;
+    font-size: 0.66rem;
+    line-height: 1.35;
+  }
+  .archive-row {
+    display: grid;
+    gap: 0.35rem;
+    padding: 0.42rem;
+    border: 1px solid #1e293b;
+    border-radius: 5px;
+    background: #0a0e17;
+  }
+  .archive-row-main {
+    min-width: 0;
+  }
+  .archive-row-name {
+    display: block;
+    color: #cbd5e1;
+    font-size: 0.69rem;
+    font-weight: 650;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .archive-row-meta {
+    display: block;
+    color: #64748b;
+    font-size: 0.61rem;
+    margin-top: 0.12rem;
+  }
+  .page-restore-btn {
+    justify-self: start;
+    background: rgba(45, 212, 191, 0.08);
+    color: #5eead4;
+    border: 1px solid rgba(45, 212, 191, 0.28);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.64rem;
+    font-weight: 650;
+    padding: 0.22rem 0.45rem;
+  }
+  .page-restore-btn:hover,
+  .page-restore-btn:focus {
+    border-color: #2dd4bf;
     outline: none;
   }
   .page-results {
@@ -582,6 +675,66 @@
     color: #475569;
     font-style: italic;
   }
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 30;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    background: rgba(2, 6, 23, 0.72);
+  }
+  .modal-backdrop.visible {
+    display: flex;
+  }
+  .modal-dialog {
+    width: min(420px, 100%);
+    border: 1px solid #334155;
+    border-radius: 8px;
+    background: #0f172a;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+    padding: 1rem;
+  }
+  .modal-title {
+    color: #f8fafc;
+    font-size: 0.95rem;
+    font-weight: 750;
+    margin-bottom: 0.35rem;
+  }
+  .modal-body {
+    color: #94a3b8;
+    font-size: 0.76rem;
+    line-height: 1.45;
+  }
+  .modal-page-name {
+    color: #e2e8f0;
+    font-weight: 700;
+  }
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+  .modal-btn {
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 0.42rem 0.65rem;
+  }
+  .modal-btn-secondary {
+    background: transparent;
+    color: #cbd5e1;
+    border: 1px solid #334155;
+  }
+  .modal-btn-danger {
+    background: rgba(248, 113, 113, 0.12);
+    color: #fecaca;
+    border: 1px solid rgba(248, 113, 113, 0.42);
+  }
 
   /* Preview area */
   .preview-area {
@@ -758,7 +911,15 @@
           <button class="page-tool-btn btn-rescan" id="page-rescan" type="button" onclick="triggerRescan()">Re-scan project</button>
         </div>
         <div class="page-edit-row">
-          <button class="page-tool-btn" id="page-edit-toggle" type="button" onclick="togglePageEditMode()" aria-pressed="false">Edit pages</button>
+          <button class="page-tool-btn with-icon" id="page-edit-toggle" type="button" onclick="togglePageEditMode()" aria-pressed="false" title="Edit pages"></button>
+        </div>
+        <div class="archive-manager" id="archive-manager">
+          <div class="archive-manager-title">
+            <span>Archived pages</span>
+          </div>
+          <div class="archive-manager-list" id="archive-list">
+            <span class="archive-empty">Loading archived pages...</span>
+          </div>
         </div>
         <div class="page-versions" id="versions-section">
           <span class="page-versions-label">Versions</span>
@@ -793,18 +954,36 @@
   </div>
 </div>
 
+<div class="modal-backdrop" id="archive-modal" role="dialog" aria-modal="true" aria-labelledby="archive-modal-title">
+  <div class="modal-dialog">
+    <div class="modal-title" id="archive-modal-title">Archive page?</div>
+    <div class="modal-body">
+      This moves <span class="modal-page-name" id="archive-modal-page"></span> out of active Factory pages and into <span class="modal-page-name">factory/archive</span>. You can restore it later from Edit pages.
+    </div>
+    <div class="modal-actions">
+      <button class="modal-btn modal-btn-secondary" type="button" onclick="closeArchiveModal()">Cancel</button>
+      <button class="modal-btn modal-btn-danger" id="archive-confirm-btn" type="button" onclick="confirmArchivePage()">
+        <i data-lucide="archive"></i>
+        <span>Archive page</span>
+      </button>
+    </div>
+  </div>
+</div>
+
 <script>
 // --- State ---
 var activeFile = null;
 var activePage = null;
 var activeVersion = null;
 var allSlots = [];
+var archivedSlots = [];
 var compareMode = false;
 var compareItems = [];
 var currentViewport = 'desktop';
 var expandedGroups = {};
 var pageGroupMode = 'compact';
 var pageEditMode = false;
+var pendingArchiveSlot = null;
 var previewFileBase = '/page?file=';
 var pageFilters = { query: '', category: '', sort: 'updated-desc' };
 
@@ -839,6 +1018,26 @@ function makeText(tag, className, text) {
   if (className) el.className = className;
   el.textContent = text;
   return el;
+}
+
+function iconEl(name) {
+  var el = document.createElement('i');
+  el.setAttribute('data-lucide', name);
+  el.setAttribute('aria-hidden', 'true');
+  return el;
+}
+
+function setIconButtonContent(button, iconName, label) {
+  clearChildren(button);
+  button.appendChild(iconEl(iconName));
+  button.appendChild(makeText('span', '', label));
+  refreshIcons();
+}
+
+function refreshIcons() {
+  if (window.lucide && typeof window.lucide.createIcons === 'function') {
+    window.lucide.createIcons();
+  }
 }
 
 function buildPreviewUrl(filePath) {
@@ -978,12 +1177,15 @@ function updatePageEditButton() {
   if (!btn) return;
   btn.classList.toggle('active', pageEditMode);
   btn.setAttribute('aria-pressed', pageEditMode ? 'true' : 'false');
-  btn.textContent = pageEditMode ? 'Done editing' : 'Edit pages';
+  btn.title = pageEditMode ? 'Done editing' : 'Edit pages';
+  setIconButtonContent(btn, pageEditMode ? 'check' : 'square-pen', pageEditMode ? 'Done editing' : 'Edit pages');
 }
 
 function togglePageEditMode() {
   pageEditMode = !pageEditMode;
   updatePageEditButton();
+  renderArchiveManager();
+  if (pageEditMode) loadArchivedSlots();
   renderPagesList();
 }
 
@@ -1207,10 +1409,12 @@ function renderPagesList() {
       var archiveBtn = document.createElement('button');
       archiveBtn.className = 'page-archive-btn';
       archiveBtn.type = 'button';
-      archiveBtn.textContent = 'Archive page';
+      archiveBtn.title = 'Archive page';
+      archiveBtn.appendChild(iconEl('archive'));
+      archiveBtn.appendChild(makeText('span', '', 'Archive page'));
       archiveBtn.onclick = function(event) {
         event.stopPropagation();
-        archivePage(slotData);
+        openArchiveModal(slotData);
       };
       actions.appendChild(archiveBtn);
       row.appendChild(actions);
@@ -1221,6 +1425,7 @@ function renderPagesList() {
     group.appendChild(rows);
     pagesList.appendChild(group);
   });
+  refreshIcons();
 }
 
 function selectInitialPage() {
@@ -1322,11 +1527,86 @@ function loadSlots() {
     });
 }
 
+function loadArchivedSlots() {
+  return fetch('/api/archived-pages')
+    .then(function(r) { return r.json(); })
+    .then(function(slots) {
+      archivedSlots = slots || [];
+      renderArchiveManager();
+      return archivedSlots;
+    })
+    .catch(function() {
+      archivedSlots = [];
+      renderArchiveManager('Could not load archived pages');
+      return [];
+    });
+}
+
+function renderArchiveManager(errorText) {
+  var panel = document.getElementById('archive-manager');
+  var list = document.getElementById('archive-list');
+  if (!panel || !list) return;
+  panel.classList.toggle('visible', pageEditMode);
+  clearChildren(list);
+  if (!pageEditMode) return;
+  if (errorText) {
+    list.appendChild(makeText('span', 'archive-empty', errorText));
+    return;
+  }
+  if (!archivedSlots || archivedSlots.length === 0) {
+    list.appendChild(makeText('span', 'archive-empty', 'No archived pages yet.'));
+    return;
+  }
+  archivedSlots.forEach(function(slotData) {
+    var row = document.createElement('div');
+    row.className = 'archive-row';
+
+    var main = document.createElement('div');
+    main.className = 'archive-row-main';
+    main.appendChild(makeText('span', 'archive-row-name', getPageContextLabel(slotData)));
+    main.appendChild(makeText('span', 'archive-row-meta', slotData.iterations.length + ' version' + (slotData.iterations.length === 1 ? '' : 's')));
+    row.appendChild(main);
+
+    var restoreBtn = document.createElement('button');
+    restoreBtn.className = 'page-restore-btn';
+    restoreBtn.type = 'button';
+    restoreBtn.title = 'Restore page';
+    restoreBtn.appendChild(iconEl('rotate-ccw'));
+    restoreBtn.appendChild(makeText('span', '', 'Restore'));
+    restoreBtn.onclick = function() { restoreArchivedPage(slotData); };
+    row.appendChild(restoreBtn);
+
+    list.appendChild(row);
+  });
+  refreshIcons();
+}
+
+function openArchiveModal(slotData) {
+  if (!slotData) return;
+  pendingArchiveSlot = slotData;
+  var pageName = document.getElementById('archive-modal-page');
+  if (pageName) pageName.textContent = getPageContextLabel(slotData);
+  var modal = document.getElementById('archive-modal');
+  if (modal) modal.classList.add('visible');
+  refreshIcons();
+}
+
+function closeArchiveModal() {
+  pendingArchiveSlot = null;
+  var modal = document.getElementById('archive-modal');
+  if (modal) modal.classList.remove('visible');
+}
+
+function confirmArchivePage() {
+  var slotData = pendingArchiveSlot;
+  if (!slotData) return;
+  archivePage(slotData);
+}
+
 function archivePage(slotData) {
   if (!slotData) return;
-  var label = getPageContextLabel(slotData);
-  var confirmed = window.confirm('Archive page: ' + label + '?\\n\\nThis moves it to factory/archive so it can be restored manually.');
-  if (!confirmed) return;
+  var btn = document.getElementById('archive-confirm-btn');
+  if (btn) btn.disabled = true;
 
   fetch('/api/archive-page', {
     method: 'POST',
@@ -1336,14 +1616,39 @@ function archivePage(slotData) {
     .then(function(r) { return r.json().then(function(data) { return { ok: r.ok, data: data }; }); })
     .then(function(result) {
       if (!result.ok) throw new Error(result.data && result.data.error ? result.data.error : 'Archive failed');
+      closeArchiveModal();
       if (slotData.slot === activePage) {
         window.location.href = '/factory';
         return;
       }
       loadSlots();
+      loadArchivedSlots();
     })
     .catch(function(err) {
       window.alert('Could not archive page: ' + err.message);
+    })
+    .then(function() {
+      if (btn) btn.disabled = false;
+    });
+}
+
+function restoreArchivedPage(slotData) {
+  if (!slotData) return;
+  fetch('/api/restore-page', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ page: slotData.slot })
+  })
+    .then(function(r) { return r.json().then(function(data) { return { ok: r.ok, data: data }; }); })
+    .then(function(result) {
+      if (!result.ok) throw new Error(result.data && result.data.error ? result.data.error : 'Restore failed');
+      return loadSlots();
+    })
+    .then(function() {
+      loadArchivedSlots();
+    })
+    .catch(function(err) {
+      window.alert('Could not restore page: ' + err.message);
     });
 }
 
@@ -1384,6 +1689,8 @@ function renderSlots(slots) {
 }
 
 // --- Load slots ---
+updatePageEditButton();
+renderArchiveManager();
 loadSlots();
 
 // --- Style Controls ---
@@ -1841,7 +2148,9 @@ function exitCompareMode() {
 }
 
 document.addEventListener('keydown', function(e) {
-  if (e.key === 'Escape' && compareMode) {
+  if (e.key === 'Escape' && document.getElementById('archive-modal').classList.contains('visible')) {
+    closeArchiveModal();
+  } else if (e.key === 'Escape' && compareMode) {
     exitCompareMode();
   }
 });

--- a/plugins/ctx/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/server.js
@@ -507,10 +507,8 @@ function sanitizePathPart(value) {
   return String(value || "").trim().replace(/[^a-zA-Z0-9_-]/g, "");
 }
 
-function scanSlots() {
-  if (!pagesRoot) return [];
-  const factoryPagesDir = path.join(pagesRoot, "factory/pages");
-  if (!fs.existsSync(factoryPagesDir)) return [];
+function scanSlotDirectory(rootDir) {
+  if (!fs.existsSync(rootDir)) return [];
 
   const slots = new Map();
 
@@ -558,7 +556,7 @@ function scanSlots() {
     }
   }
 
-  scan(factoryPagesDir, "");
+  scan(rootDir, "");
 
   // Sort iterations within each slot by version number
   const result = [];
@@ -580,6 +578,16 @@ function scanSlots() {
     return a.page.localeCompare(b.page);
   });
   return result;
+}
+
+function scanSlots() {
+  if (!pagesRoot) return [];
+  return scanSlotDirectory(path.join(pagesRoot, "factory/pages"));
+}
+
+function scanArchivedSlots() {
+  if (!pagesRoot) return [];
+  return scanSlotDirectory(path.join(pagesRoot, "factory/archive"));
 }
 
 // ========== Auto-Versioning ==========
@@ -791,6 +799,52 @@ async function handleArchivePage(req, res) {
   });
 }
 
+async function handleRestorePage(req, res) {
+  if (!pagesRoot) {
+    jsonResponse(res, 400, { error: "No --project-dir configured" });
+    return;
+  }
+
+  const body = await readBody(req);
+  if (!body || !body.page) {
+    jsonResponse(res, 400, { error: "Missing page" });
+    return;
+  }
+
+  const slot = String(body.page).trim();
+  const slotData = scanArchivedSlots().find(s => s.slot === slot);
+  if (!slotData) {
+    jsonResponse(res, 404, { error: "Archived page not found" });
+    return;
+  }
+
+  const pagesDir = path.resolve(pagesRoot, "factory/pages");
+  const archiveDir = path.resolve(pagesRoot, "factory/archive");
+  const source = path.resolve(archiveDir, slotData.slot);
+  const target = path.resolve(pagesDir, slotData.slot);
+  if (!source.startsWith(archiveDir + path.sep) || !fs.existsSync(source)) {
+    jsonResponse(res, 404, { error: "Archived page directory not found" });
+    return;
+  }
+  if (!target.startsWith(pagesDir + path.sep)) {
+    jsonResponse(res, 403, { error: "Forbidden restore path" });
+    return;
+  }
+  if (fs.existsSync(target)) {
+    jsonResponse(res, 409, { error: "An active page already exists at this path" });
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.renameSync(source, target);
+  broadcast({ type: "reload" });
+  jsonResponse(res, 200, {
+    ok: true,
+    page: slotData.slot,
+    restoredTo: path.relative(pagesRoot, target),
+  });
+}
+
 function servePortfolio(res) {
   const portfolioPath = path.join(__dirname, "portfolio.html");
   if (!fs.existsSync(portfolioPath)) {
@@ -840,8 +894,12 @@ const server = http.createServer((req, res) => {
     handleWrite(req, res);
   } else if (parsed.pathname === "/api/page-status") {
     handlePageStatus(req, res);
+  } else if (parsed.pathname === "/api/archived-pages") {
+    jsonResponse(res, 200, scanArchivedSlots());
   } else if (parsed.pathname === "/api/archive-page" && req.method === "POST") {
     handleArchivePage(req, res);
+  } else if (parsed.pathname === "/api/restore-page" && req.method === "POST") {
+    handleRestorePage(req, res);
   } else if (parsed.pathname === "/api/compare" && req.method === "POST") {
     handleCompare(req, res);
   } else if (parsed.pathname === "/api/style-profile") {

--- a/plugins/ctx/skills/ctx-brainstorm/factory/server.js
+++ b/plugins/ctx/skills/ctx-brainstorm/factory/server.js
@@ -744,6 +744,53 @@ function handlePageStatus(req, res) {
   jsonResponse(res, 200, result);
 }
 
+async function handleArchivePage(req, res) {
+  if (!pagesRoot) {
+    jsonResponse(res, 400, { error: "No --project-dir configured" });
+    return;
+  }
+
+  const body = await readBody(req);
+  if (!body || !body.page) {
+    jsonResponse(res, 400, { error: "Missing page" });
+    return;
+  }
+
+  const slot = String(body.page).trim();
+  const slotData = scanSlots().find(s => s.slot === slot);
+  if (!slotData) {
+    jsonResponse(res, 404, { error: "Page not found" });
+    return;
+  }
+
+  const pagesDir = path.resolve(pagesRoot, "factory/pages");
+  const archiveDir = path.resolve(pagesRoot, "factory/archive");
+  const source = path.resolve(pagesDir, slotData.slot);
+  if (!source.startsWith(pagesDir + path.sep) || !fs.existsSync(source)) {
+    jsonResponse(res, 404, { error: "Page directory not found" });
+    return;
+  }
+
+  let target = path.resolve(archiveDir, slotData.slot);
+  if (!target.startsWith(archiveDir + path.sep)) {
+    jsonResponse(res, 403, { error: "Forbidden archive path" });
+    return;
+  }
+
+  if (fs.existsSync(target)) {
+    target = target + "-" + new Date().toISOString().replace(/[:.]/g, "-");
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.renameSync(source, target);
+  broadcast({ type: "reload" });
+  jsonResponse(res, 200, {
+    ok: true,
+    page: slotData.slot,
+    archivedTo: path.relative(pagesRoot, target),
+  });
+}
+
 function servePortfolio(res) {
   const portfolioPath = path.join(__dirname, "portfolio.html");
   if (!fs.existsSync(portfolioPath)) {
@@ -793,6 +840,8 @@ const server = http.createServer((req, res) => {
     handleWrite(req, res);
   } else if (parsed.pathname === "/api/page-status") {
     handlePageStatus(req, res);
+  } else if (parsed.pathname === "/api/archive-page" && req.method === "POST") {
+    handleArchivePage(req, res);
   } else if (parsed.pathname === "/api/compare" && req.method === "POST") {
     handleCompare(req, res);
   } else if (parsed.pathname === "/api/style-profile") {


### PR DESCRIPTION
## Summary
- add an icon-led Edit pages mode to the Factory editor sidebar
- show Archive page actions only while edit mode is active
- replace direct archive confirmation with a Factory modal with Cancel and Archive page actions
- add soft archive support that moves page folders from factory/pages into factory/archive
- add archived page listing and restore support via /api/archived-pages and /api/restore-page
- keep restore safe by refusing to overwrite an active page at the same path
- keep rescan as a single top Pages action and clarify Style Controls as preview-only overrides
- mirror the Factory UI and server behavior across plugins/ctx-codex and plugins/ctx

## Validation
- node --check plugins/ctx-codex/skills/ctx-brainstorm/factory/server.js
- node --check plugins/ctx/skills/ctx-brainstorm/factory/server.js
- git diff --check main...HEAD
- archive/restore endpoint smoke passed against a temporary throwaway Factory project before rebasing to this fresh main branch
- in-app browser smoke passed before rebasing: archive hidden before edit mode, visible after Edit pages, modal opens, and Cancel closes without archiving

## Notes
- Real Factory pages were not archived during validation. The endpoint smoke used a temporary throwaway project.
- This supersedes #57, which was based on the earlier branch.