### PR TITLE
feat(discuss): add UI discussion reference

### DIFF
--- a/plugins/ctx-codex/skills/ctx-discuss/SKILL.md
+++ b/plugins/ctx-codex/skills/ctx-discuss/SKILL.md
@@ -16,6 +16,7 @@ You are in discussion mode. The user wants to think out loud and discover what t
 - Do NOT make code changes. Read-only exploration (reading files, searching code) is fine.
 - Ask questions and challenge thinking. Help the user discover what they want.
 - Apply the three gates from `ctx-engineering` to the discussion itself: Is the intent clear? Are success criteria emerging? Are we grounded in facts?
+- For UI/frontend/component/product-polish discussion, read `references/ui-discuss.md` and use that tighter response shape.
 - Be honest. Say "I don't know" when you don't know. Push back when reasoning is shallow.
 
 ## Exit

--- a/plugins/ctx-codex/skills/ctx-discuss/references/ui-discuss.md
+++ b/plugins/ctx-codex/skills/ctx-discuss/references/ui-discuss.md
@@ -1,0 +1,37 @@
+# UI Discuss
+
+Use this reference when discussion is about UI, frontend implementation, component behavior, layout, copy, interaction states, or visual polish.
+
+## Response Shape
+
+Use terse, implementation-shaped answers:
+
+```md
+**Topic Name**
+- Recommendation: ...
+- CSS/state: `...`
+- Behavior: `...`
+- Risk: ...
+```
+
+## Preferences
+
+- Prefer bullets over prose.
+- Prefer code tokens over explanation.
+- Include exact implementation primitives when useful:
+  - `max-h-[184px]`
+  - `overflow-y-auto`
+  - `scrollbar-gutter: stable`
+  - `scrollHeight - scrollTop - clientHeight > 1`
+  - `ml-8`
+  - `z-10`
+  - `shadow-[...]`
+- Name the component or UI region first.
+- Include one tradeoff or risk only when it changes the decision.
+
+## Avoid
+
+- Long rationale.
+- Generic encouragement.
+- Repeating obvious screen context.
+- Marketing copy unless copy is the topic.

--- a/plugins/ctx/skills/ctx-discuss/SKILL.md
+++ b/plugins/ctx/skills/ctx-discuss/SKILL.md
@@ -16,6 +16,7 @@ You are in discussion mode. The user wants to think out loud and discover what t
 - Do NOT make code changes. Read-only exploration (reading files, searching code) is fine.
 - Ask questions and challenge thinking. Help the user discover what they want.
 - Apply the three gates from `/ctx-engineering` to the discussion itself: Is the intent clear? Are success criteria emerging? Are we grounded in facts?
+- For UI/frontend/component/product-polish discussion, read `references/ui-discuss.md` and use that tighter response shape.
 - Be honest. Say "I don't know" when you don't know. Push back when reasoning is shallow.
 
 ## Exit

--- a/plugins/ctx/skills/ctx-discuss/references/ui-discuss.md
+++ b/plugins/ctx/skills/ctx-discuss/references/ui-discuss.md
@@ -1,0 +1,37 @@
+# UI Discuss
+
+Use this reference when discussion is about UI, frontend implementation, component behavior, layout, copy, interaction states, or visual polish.
+
+## Response Shape
+
+Use terse, implementation-shaped answers:
+
+```md
+**Topic Name**
+- Recommendation: ...
+- CSS/state: `...`
+- Behavior: `...`
+- Risk: ...
+```
+
+## Preferences
+
+- Prefer bullets over prose.
+- Prefer code tokens over explanation.
+- Include exact implementation primitives when useful:
+  - `max-h-[184px]`
+  - `overflow-y-auto`
+  - `scrollbar-gutter: stable`
+  - `scrollHeight - scrollTop - clientHeight > 1`
+  - `ml-8`
+  - `z-10`
+  - `shadow-[...]`
+- Name the component or UI region first.
+- Include one tradeoff or risk only when it changes the decision.
+
+## Avoid
+
+- Long rationale.
+- Generic encouragement.
+- Repeating obvious screen context.
+- Marketing copy unless copy is the topic.


### PR DESCRIPTION
## Summary
- Add a UI-specific discussion reference for terse implementation-shaped frontend/product polish conversations
- Wire both ctx-codex and ctx discuss skills to load the reference for UI/frontend/component discussions
- Keep existing discuss behavior unchanged for non-UI exploration

## Verification
- Confirmed staged diff only includes ctx-discuss skill/reference files
- Copied the reference into active local Claude/Codex plugin cache copies for immediate use